### PR TITLE
fix(seo): robust sitemap generation & robots.txt updates

### DIFF
--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -24,7 +24,7 @@ export default function HistoryPage() {
         />
 
         {/* Content */}
-        <div className="flex-1 p-4 pb-20">
+        <div className="flex-1 p-4">
           <React.Suspense
             fallback={
               <div className="h-40 flex items-center justify-center">

--- a/src/app/profile/orders/[id]/page.tsx
+++ b/src/app/profile/orders/[id]/page.tsx
@@ -120,7 +120,7 @@ export default function OrderDetailPage() {
           onBack={() => router.push("/profile/orders")}
         />
 
-        <main className="flex-1 p-4 pb-20 space-y-6">
+        <main className="flex-1 p-4 space-y-6">
           {/* Status Section */}
           {order.status !== "paid" && (
             <Card
@@ -213,7 +213,7 @@ export default function OrderDetailPage() {
               <h3 className="text-xs font-bold text-muted-foreground uppercase tracking-widest px-1">
                 Rincian Paket
               </h3>
-            <Card className="border-border/50 shadow-sm rounded-2xl overflow-hidden">
+              <Card className="border-border/50 shadow-sm rounded-2xl overflow-hidden">
                 <CardContent className="p-5 space-y-4">
                   <div className="flex items-start justify-between">
                     <div className="flex items-center gap-3">

--- a/src/app/profile/orders/page.tsx
+++ b/src/app/profile/orders/page.tsx
@@ -61,7 +61,7 @@ export default function OrdersPage() {
           onBack={() => router.push("/profile")}
         />
 
-        <main className="flex-1 p-4 pb-20">
+        <main className="flex-1 p-4">
           {isLoading ? (
             <div className="space-y-4">
               {[1, 2, 3].map((i) => (

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -174,7 +174,7 @@ export default function ProfilePage() {
       <div className="min-h-screen bg-background flex flex-col items-center">
         <Header title="Profil & Pengaturan" showBackButton />
 
-        <main className="w-full max-w-[600px] pb-10">
+        <main className="w-full max-w-[600px]">
           {/* Banner Section */}
           <div className="w-full px-4 pt-4">
             <div className="relative aspect-[360/113] w-full overflow-hidden rounded-lg">

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,18 +1,23 @@
 import { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
+  const baseUrl = "https://splitbill.my.id";
+  
   return {
     rules: {
       userAgent: "*",
-      allow: "/",
+      allow: ["/", "/sitemap.xml"],
       disallow: [
         "/api/",       // Jangan indeks endpoint API
         "/admin/",     // Folder admin (jika ada)
         "/_next/",     // Folder internal Next.js
         "/static/",    // Static files biasanya sudah di-handle
         "/*.json$",    // File konfigurasi JSON
+        "/profile",    // Protected route
+        "/wallet",     // Protected route
+        "/history",    // Protected route
       ],
     },
-    sitemap: "https://splitbill.my.id/sitemap.xml",
+    sitemap: `${baseUrl}/sitemap.xml`,
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,14 +8,12 @@ interface RouteConfig {
 }
 
 const routeConfigs: RouteConfig[] = [
-  { path: "", priority: 1.0, changeFrequency: "daily" },
+  { path: "/", priority: 1.0, changeFrequency: "daily" },
   { path: "/blog", priority: 0.9, changeFrequency: "daily" },
   { path: "/split-bill", priority: 0.9, changeFrequency: "weekly" },
   { path: "/collect-money", priority: 0.8, changeFrequency: "weekly" },
   { path: "/shared-goals", priority: 0.8, changeFrequency: "weekly" },
   { path: "/split-later", priority: 0.8, changeFrequency: "weekly" },
-  { path: "/wallet", priority: 0.7, changeFrequency: "monthly" },
-  { path: "/history", priority: 0.6, changeFrequency: "weekly" },
   { path: "/invoice", priority: 0.8, changeFrequency: "weekly" },
   { path: "/membership", priority: 0.6, changeFrequency: "monthly" },
   { path: "/review", priority: 0.7, changeFrequency: "weekly" },
@@ -32,7 +30,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // Static routes
   const staticRoutes = routeConfigs.map(({ path, priority, changeFrequency }) => ({
-    url: `${baseUrl}${path}`,
+    url: `${baseUrl}${path === "/" ? "" : path}`,
     lastModified: now,
     changeFrequency,
     priority,
@@ -41,17 +39,38 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // Dynamic Blog routes
   let blogRoutes: MetadataRoute.Sitemap = [];
   try {
+    // Add a timeout to the fetch if possible, but here we just catch the error
     const blogsRes = await fetchBlogs({ limit: 1000 });
-    if (blogsRes.success && blogsRes.data) {
-      blogRoutes = blogsRes.data.map((blog) => ({
-        url: `${baseUrl}/blog/${blog.slug}`,
-        lastModified: new Date(blog.updatedAt || blog.publishedAt || blog.createdAt),
-        changeFrequency: "weekly" as const,
-        priority: 0.7,
-      }));
+    
+    if (blogsRes && blogsRes.success && Array.isArray(blogsRes.data)) {
+      blogRoutes = blogsRes.data
+        .filter(blog => blog.status === "published" && blog.slug)
+        .map((blog) => {
+          // Ensure we have a valid date
+          let lastMod = now;
+          try {
+            const dateStr = blog.updatedAt || blog.publishedAt || blog.createdAt;
+            if (dateStr) {
+              const d = new Date(dateStr);
+              if (!isNaN(d.getTime())) {
+                lastMod = d;
+              }
+            }
+          } catch (e) {
+            // Fallback to now
+          }
+
+          return {
+            url: `${baseUrl}/blog/${blog.slug}`,
+            lastModified: lastMod,
+            changeFrequency: "weekly" as const,
+            priority: 0.7,
+          };
+        });
     }
   } catch (error) {
     console.error("Failed to fetch blogs for sitemap:", error);
+    // Continue with just static routes
   }
 
   return [...staticRoutes, ...blogRoutes];

--- a/src/app/split-later/[bucketId]/BucketDetailClientPage.tsx
+++ b/src/app/split-later/[bucketId]/BucketDetailClientPage.tsx
@@ -302,6 +302,7 @@ export default function BucketDetailClientPage({
               <BucketSettlement
                 receipts={receipts}
                 participants={bucket.participants}
+                bucket={bucket}
               />
             )}
           </div>

--- a/src/components/home/HomePageClient.tsx
+++ b/src/components/home/HomePageClient.tsx
@@ -255,7 +255,7 @@ export const HomePageClient = () => {
               onPrimaryClick={() => router.push("/split-bill?step=1")}
               imageSrc="/img/hero-splitbill.png"
               floatingCard={<HeroFloatingCard />}
-              trustText="🔥 Dipakai ribuan grup nongkrong & trip tiap hari"
+              trustText="Andalan ribuan grup & trip! 🔥"
             />
           </div>
         )}

--- a/src/components/split-later/BucketFormBottomSheet.tsx
+++ b/src/components/split-later/BucketFormBottomSheet.tsx
@@ -192,7 +192,7 @@ export const BucketFormBottomSheet = ({
 
       <div
         className={cn(
-          "absolute bottom-0 w-full max-w-[600px] bg-white rounded-t-3xl shadow-2xl overflow-hidden flex flex-col max-h-[95vh]",
+          "absolute bottom-0 w-full max-w-[600px] bg-white rounded-t-3xl shadow-2xl overflow-hidden flex flex-col max-h-[80dvh]",
           "animate-in slide-in-from-bottom-full duration-300 ease-out",
         )}
       >

--- a/src/components/split-later/BucketSettlement.tsx
+++ b/src/components/split-later/BucketSettlement.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { BucketReceipt } from "@/store/useSplitLaterStore";
+import { BucketReceipt, SplitLaterBucket } from "@/store/useSplitLaterStore";
 import { useWalletStore } from "@/store/useWalletStore";
 import { Card, CardContent } from "@/components/ui/Card";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -13,13 +13,20 @@ import {
   Users,
   ChevronDown,
   ChevronUp,
+  Share2,
+  Image as ImageIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { HowToReadSummary } from "@/components/splitbill/HowToReadSummary";
+import { toast } from "sonner";
+import * as htmlToImage from "html-to-image";
+import { SocialSplitLaterReceipt } from "./SocialSplitLaterReceipt";
+import Image from "next/image";
 
 interface BucketSettlementProps {
   receipts: BucketReceipt[];
   participants: string[];
+  bucket: SplitLaterBucket;
 }
 
 interface SettlementItem {
@@ -44,17 +51,26 @@ interface SettlementInstruction {
   amount: number;
 }
 
+const WhatsAppIcon = ({ className }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
+  </svg>
+);
+
 const AVATAR_BASE_URL =
   "https://api.dicebear.com/9.x/personas/png?backgroundColor=b6e3f4,c0aede,d1d4f9,ffd5dc,ffdfbf&size=64&seed=";
 
 export const BucketSettlement = ({
   receipts,
   participants,
+  bucket,
 }: BucketSettlementProps) => {
-  const { savedBills } = useWalletStore();
+  const { savedBills, paymentMethods } = useWalletStore();
   const [expandedPeople, setExpandedPeople] = React.useState<
     Record<string, boolean>
   >({});
+  const [isSharing, setIsSharing] = React.useState(false);
+  const socialReceiptRef = React.useRef<HTMLDivElement>(null);
 
   const togglePerson = (name: string) => {
     setExpandedPeople((prev) => ({
@@ -248,6 +264,115 @@ export const BucketSettlement = ({
     0,
   );
 
+  const badges = React.useMemo<Record<string, string[]>>(() => {
+    const badgeMap: Record<string, string[]> = {};
+    participants.forEach((name) => {
+      badgeMap[name] = [];
+    });
+
+    if (balances.length >= 2) {
+      const activeSpenders = balances
+        .filter((b) => b.totalOwed > 0.1)
+        .sort((a, b) => b.totalOwed - a.totalOwed);
+
+      if (activeSpenders.length > 0) {
+        // 1. Si Paling Traktir (Paid the most overall)
+        const topPayer = [...activeSpenders].sort((a, b) => b.totalPaid - a.totalPaid)[0];
+        if (topPayer && topPayer.totalPaid > 0.01) {
+          badgeMap[topPayer.name] = ["Si Paling Traktir"];
+        }
+
+        // 2. Si Paling Sultan (Spent the most overall)
+        const topSpender = activeSpenders[0];
+        if (topSpender) {
+          if (!badgeMap[topSpender.name]) {
+            badgeMap[topSpender.name] = [];
+          }
+          if (badgeMap[topSpender.name].length === 0) {
+            badgeMap[topSpender.name].push("Si Paling Sultan");
+          }
+        }
+
+        // 3. Si Paling Hemat (Spent the least overall but active)
+        const potentialLowestSpenders = [...activeSpenders].reverse();
+        const lowestSpenderCandidate = potentialLowestSpenders.find(
+          (s) => s.name !== topSpender?.name && (!badgeMap[s.name] || badgeMap[s.name].length === 0)
+        );
+
+        if (lowestSpenderCandidate && activeSpenders.length >= 2) {
+          if (!badgeMap[lowestSpenderCandidate.name]) {
+            badgeMap[lowestSpenderCandidate.name] = [];
+          }
+          badgeMap[lowestSpenderCandidate.name].push("Si Paling Hemat");
+        }
+      }
+    }
+
+    return badgeMap;
+  }, [balances, participants]);
+
+  const handleShareSocial = async () => {
+    if (!socialReceiptRef.current) return;
+
+    setIsSharing(true);
+    const toastId = toast.loading("Menyiapkan gambar keren buat sosmed...");
+
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      const dataUrl = await htmlToImage.toPng(socialReceiptRef.current, {
+        quality: 1,
+        pixelRatio: 2,
+        backgroundColor: "#ffffff",
+      });
+
+      const fileName = `SplitLater-${bucket.title?.replace(/\s+/g, "-") || "Summary"}-${Date.now()}.png`;
+      const caption = `💸 Settlement Rangkuman untuk "${bucket.emoji || "✈️"} ${bucket.title || "Trip Kami"}"!\n\nTotal pengeluaran trip ini ${formatToIDR(totalSpend)}.\n\nPowered by splitbill.my.id`;
+
+      if (
+        typeof navigator !== "undefined" &&
+        navigator.share &&
+        navigator.canShare
+      ) {
+        try {
+          const res = await fetch(dataUrl);
+          const blob = await res.blob();
+          const file = new File([blob], fileName, { type: "image/png" });
+
+          if (navigator.canShare({ files: [file] })) {
+            await navigator.share({
+              files: [file],
+              title: bucket.title || "Split Later Settlement",
+              text: caption,
+            });
+            toast.success("Berhasil dibagikan! 📸✨", { id: toastId });
+            return;
+          }
+        } catch (shareErr) {
+          console.warn(
+            "Native share failed, falling back to download:",
+            shareErr,
+          );
+        }
+      }
+
+      // Fallback: Download behavior
+      const link = document.createElement("a");
+      link.download = fileName;
+      link.href = dataUrl;
+      link.click();
+
+      toast.success("Gambar berhasil dibuat! Tinggal share deh. 📸✨", {
+        id: toastId,
+      });
+    } catch (err) {
+      console.error("Sharing failed:", err);
+      toast.error("Gagal membagikan gambar.", { id: toastId });
+    } finally {
+      setIsSharing(false);
+    }
+  };
+
   if (completedReceipts.length === 0) {
     return (
       <EmptyState
@@ -261,25 +386,67 @@ export const BucketSettlement = ({
 
   return (
     <div className="space-y-4">
-      {/* Summary card */}
-      <Card className="border-none shadow-soft bg-primary text-white">
-        <CardContent className="p-5">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-[10px] font-bold uppercase tracking-widest text-white/70">
-                Total Pengeluaran Trip
-              </p>
-              <p className="text-3xl font-black tracking-tight mt-1">
-                {formatToIDR(totalSpend)}
-              </p>
-              <p className="text-xs text-white/70 mt-1">
-                dari {completedReceipts.length} struk yang sudah diproses
-              </p>
+      {/* Encourage to Share Card (SaveBillNudge style) */}
+      <Card className="border border-primary/20 shadow-soft bg-primary/5 overflow-hidden rounded-2xl">
+        <CardContent className="p-5 space-y-4">
+          <div className="flex items-start gap-4">
+            <div className="w-10 h-10 rounded-xl relative overflow-hidden shrink-0">
+              <Image
+                src="/img/save-bill-icon.png"
+                alt="Save Bill Icon"
+                fill
+                className="object-contain"
+              />
             </div>
-            <div className="w-12 h-12 rounded-2xl bg-white/20 flex items-center justify-center">
-              <TrendingUp className="w-6 h-6 text-white" />
+            <div className="space-y-1">
+              <h3 className="text-lg font-bold text-foreground">
+                Bagikan Settlement Trip! 📸
+              </h3>
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                <strong>{completedReceipts.length} struk</strong> kelar di-split share gambar settlement ke grup sekarang! 😉
+              </p>
             </div>
           </div>
+
+          <div className="flex items-center gap-4 px-1">
+            <div className="flex -space-x-2">
+              {[TrendingUp, ImageIcon, WhatsAppIcon].map((Icon, i) => (
+                <div
+                  key={i}
+                  className={cn(
+                    "w-7 h-7 rounded-full flex items-center justify-center shadow-sm relative border-2 border-white",
+                    i === 0
+                      ? "z-0 bg-amber-50 text-amber-500"
+                      : i === 1
+                        ? "z-10 bg-blue-50 text-blue-500"
+                        : "z-20 bg-emerald-50 text-emerald-500",
+                  )}
+                >
+                  <Icon className={cn("w-3.5 h-3.5", i === 2 && "w-3 h-3")} />
+                </div>
+              ))}
+            </div>
+            <p className="text-[10px] font-bold text-primary/60 uppercase tracking-wider">
+              Auto-download gambar & langsung share ke sosmed! 📸
+            </p>
+          </div>
+
+          <button
+            onClick={handleShareSocial}
+            disabled={isSharing}
+            className={cn(
+              "w-full h-11 rounded-lg font-bold gap-2 text-sm transition-all active:scale-[0.98] bg-primary text-white shadow-md shadow-primary/10 flex items-center justify-center group cursor-pointer",
+              isSharing && "opacity-75 cursor-not-allowed",
+            )}
+          >
+            <Share2
+              className={cn(
+                "w-4 h-4 group-hover:rotate-12 transition-transform",
+                isSharing && "animate-pulse",
+              )}
+            />
+            {isSharing ? "Menyiapkan Gambar..." : "Bagikan Rangkuman"}
+          </button>
         </CardContent>
       </Card>
 
@@ -507,6 +674,19 @@ export const BucketSettlement = ({
 
       {/* How to Read Section */}
       <HowToReadSummary />
+
+      {/* Hidden Social Receipt for Capture */}
+      <div className="fixed -left-[2000px] top-0 pointer-events-none">
+        <SocialSplitLaterReceipt
+          ref={socialReceiptRef}
+          bucket={bucket}
+          receipts={receipts}
+          balances={balances}
+          settlements={settlements}
+          badges={badges}
+          paymentMethods={paymentMethods}
+        />
+      </div>
     </div>
   );
 };

--- a/src/components/split-later/SocialSplitLaterReceipt.tsx
+++ b/src/components/split-later/SocialSplitLaterReceipt.tsx
@@ -1,0 +1,466 @@
+"use client";
+
+import React from "react";
+import { formatToIDR } from "@/lib/utils";
+import {
+  Users,
+  TrendingUp,
+  ArrowRight,
+  Sparkles,
+  Calendar,
+  DollarSign,
+  Receipt,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { SplitLaterBucket, BucketReceipt } from "@/store/useSplitLaterStore";
+import { PaymentMethod } from "@/store/useWalletStore";
+
+const AVATAR_BASE_URL =
+  "https://api.dicebear.com/9.x/personas/png?backgroundColor=b6e3f4,c0aede,d1d4f9,ffd5dc,ffdfbf&size=128&scale=100&seed=";
+
+interface SettlementItem {
+  receiptName: string;
+  itemName: string;
+  share: number;
+  method: "equal" | "prop";
+  isAdditional: boolean;
+}
+
+interface PersonBalance {
+  name: string;
+  totalPaid: number;
+  totalOwed: number;
+  balance: number;
+  items: SettlementItem[];
+}
+
+interface SettlementInstruction {
+  from: string;
+  to: string;
+  amount: number;
+}
+
+interface SocialSplitLaterReceiptProps {
+  bucket: SplitLaterBucket;
+  receipts: BucketReceipt[];
+  balances: PersonBalance[];
+  settlements: SettlementInstruction[];
+  badges: Record<string, string[]>;
+  paymentMethods?: PaymentMethod[];
+}
+
+export const SocialSplitLaterReceipt = React.forwardRef<
+  HTMLDivElement,
+  SocialSplitLaterReceiptProps
+>(({ bucket, receipts, balances, settlements, badges, paymentMethods = [] }, ref) => {
+  const people = balances.map((b) => b.name);
+  const completedReceiptsCount = receipts.filter((r) => r.status === "completed").length;
+  const totalSpend = receipts
+    .filter((r) => r.status === "completed")
+    .reduce((sum, r) => sum + (r.totalAmount || 0), 0);
+
+  const getBadgeIcon = (badge: string) => {
+    switch (badge) {
+      case "Si Paling Traktir":
+        return "💳";
+      case "Si Paling Sultan":
+        return "👑";
+      case "Si Paling Hemat":
+        return "🍃";
+      default:
+        return "✨";
+    }
+  };
+
+  const getBadgeColor = (badge: string) => {
+    switch (badge) {
+      case "Si Paling Traktir":
+        return "bg-emerald-50 text-emerald-600 border-emerald-100";
+      case "Si Paling Sultan":
+        return "bg-amber-50 text-amber-600 border-amber-100";
+      case "Si Paling Hemat":
+        return "bg-blue-50 text-blue-600 border-blue-100";
+      default:
+        return "bg-primary/5 text-primary border-primary/10";
+    }
+  };
+
+  const currentDate = new Date().toLocaleDateString("id-ID", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+
+  return (
+    <div
+      ref={ref}
+      className="w-[1080px] bg-white pt-4 px-8 pb-8 min-h-[1080px] font-sans relative overflow-hidden flex flex-col items-center"
+    >
+      {/* Background Decorative Elements */}
+      <div className="absolute top-0 left-0 w-full h-[200px] bg-slate-50 z-0 rounded-b-[100px] border-b border-slate-100" />
+      <div className="absolute top-20 right-[-100px] w-[500px] h-[500px] bg-primary/5 rounded-full blur-3xl z-0" />
+      <div className="absolute top-[800px] left-[-200px] w-[600px] h-[600px] bg-purple-500/5 rounded-full blur-3xl z-0" />
+      <div className="absolute bottom-[-100px] right-[-100px] w-[600px] h-[600px] bg-primary/5 rounded-full blur-3xl z-0" />
+
+      {/* Branding */}
+      <div className="relative z-10 w-full flex justify-between items-center mb-8">
+        <div className="flex items-center gap-5">
+          <div className="w-20 h-20 bg-white rounded-2xl flex items-center justify-center border border-primary/5 relative overflow-hidden">
+            <img
+              src="/img/footer-icon.png"
+              alt="SplitBill Logo"
+              crossOrigin="anonymous"
+              className="w-full h-full object-contain p-2"
+            />
+          </div>
+          <div>
+            <h4 className="text-primary text-4xl font-black italic tracking-tighter leading-none">
+              SPLITBILL
+            </h4>
+            <p className="text-slate-500 text-xl font-bold uppercase tracking-widest mt-1">
+              Trip Settlement Summary
+            </p>
+          </div>
+        </div>
+        <div className="px-8 py-3 bg-primary/10 backdrop-blur-md rounded-full border border-primary/10">
+          <span className="text-primary text-2xl font-bold">
+            #SplitLaterGakPakeRibet
+          </span>
+        </div>
+      </div>
+
+      {/* Hero Section */}
+      <div className="relative z-10 w-full flex flex-col items-center text-center mt-2">
+        <div className="mb-8 relative">
+          <div className="w-36 h-36 bg-white rounded-full flex items-center justify-center relative z-10 overflow-hidden border-4 border-primary/10 text-5xl">
+            {bucket.emoji || "✈️"}
+          </div>
+          <div className="absolute inset-0 bg-primary/20 blur-2xl opacity-40 animate-pulse rounded-full" />
+        </div>
+        <h1 className="text-slate-900 text-6xl font-black tracking-tight mb-4 max-w-[900px]">
+          {bucket.title || "Trip Tanpa Nama"}
+        </h1>
+        <div className="flex items-center gap-4 text-slate-500 text-2xl font-bold uppercase tracking-widest">
+          <Calendar className="w-7 h-7 text-primary" />
+          <span>{currentDate}</span>
+        </div>
+      </div>
+
+      {/* Main Stats Card */}
+      <div className="relative z-10 w-full bg-white rounded-[50px] border border-primary/5 p-8 mt-8 flex flex-col gap-10">
+        <div className="grid grid-cols-3 gap-6 py-10 px-10 bg-primary/5 rounded-[30px] border border-primary/10">
+          <div className="flex flex-col gap-2 border-r border-primary/10">
+            <span className="text-primary text-2xl font-black uppercase tracking-widest opacity-60">
+              Total Pengeluaran
+            </span>
+            <span className="text-5xl font-black text-primary tracking-tighter">
+              {formatToIDR(totalSpend)}
+            </span>
+          </div>
+          <div className="flex flex-col gap-2 border-r border-primary/10 pl-6">
+            <span className="text-slate-500 text-2xl font-bold uppercase tracking-widest">
+              Struk Selesai
+            </span>
+            <div className="flex items-center gap-3">
+              <Receipt className="w-8 h-8 text-primary" />
+              <span className="text-5xl font-black text-slate-800">
+                {completedReceiptsCount}
+              </span>
+            </div>
+          </div>
+          <div className="flex flex-col gap-2 pl-6">
+            <span className="text-slate-500 text-2xl font-bold uppercase tracking-widest">
+              Anggota
+            </span>
+            <div className="flex items-center gap-3">
+              <Users className="w-8 h-8 text-primary" />
+              <span className="text-5xl font-black text-slate-800">
+                {people.length}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* Badges Section */}
+        {Object.values(badges).some((b) => b.length > 0) && (
+          <div className="grid grid-cols-1 gap-6">
+            <h3 className="text-3xl font-black text-slate-800 flex items-center gap-4 mb-2">
+              <Sparkles className="w-8 h-8 text-primary" />
+              Hall of Fame ✨
+            </h3>
+            <div className="grid grid-cols-2 gap-6">
+              {balances.map((person) => {
+                const personBadges = badges[person.name] || [];
+                if (personBadges.length === 0) return null;
+
+                return (
+                  <div
+                    key={person.name}
+                    className="flex items-center gap-5 p-6 bg-slate-50 rounded-[30px] border border-slate-100 transition-all hover:scale-105"
+                  >
+                    <div className="w-20 h-20 rounded-full border-4 border-white overflow-hidden bg-white shrink-0">
+                      <img
+                        src={`${AVATAR_BASE_URL}${encodeURIComponent(person.name)}`}
+                        alt={person.name}
+                        crossOrigin="anonymous"
+                        className="w-full h-full object-cover"
+                      />
+                    </div>
+                    <div className="flex flex-col gap-2 min-w-0">
+                      <span className="text-2xl font-bold text-slate-800 truncate">
+                        {person.name}
+                      </span>
+                      <div className="flex flex-nowrap gap-2 overflow-hidden">
+                        {personBadges.map((badge) => (
+                          <span
+                            key={badge}
+                            className={cn(
+                              "text-lg font-black px-4 py-1.5 rounded-full border whitespace-nowrap shrink-0",
+                              getBadgeColor(badge),
+                            )}
+                          >
+                            {getBadgeIcon(badge)} {badge}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Siapa Bayar ke Siapa Section */}
+      <div className="relative z-10 w-full mt-16 px-4">
+        <h3 className="text-3xl font-black text-slate-800 flex items-center gap-4 mb-8">
+          <ArrowRight className="w-8 h-8 text-primary" />
+          Siapa Bayar ke Siapa 💸
+        </h3>
+        <div className="grid grid-cols-1 gap-5">
+          {settlements.length > 0 ? (
+            settlements.map((inst, idx) => (
+              <div
+                key={idx}
+                className="bg-white border border-slate-100 rounded-[35px] p-8 flex items-center justify-between gap-4 transition-all"
+              >
+                <div className="flex items-center gap-6 flex-1 min-w-0">
+                  <div className="relative flex items-center shrink-0">
+                    <div className="w-16 h-16 rounded-full border-4 border-white overflow-hidden bg-white">
+                      <img
+                        src={`${AVATAR_BASE_URL}${encodeURIComponent(inst.from)}`}
+                        alt={inst.from}
+                        crossOrigin="anonymous"
+                        className="w-full h-full object-cover"
+                      />
+                    </div>
+                    <div className="w-10 h-10 bg-white rounded-full flex items-center justify-center mx-[-8px] z-10 border-2 border-slate-50">
+                      <ArrowRight className="w-5 h-5 text-primary" />
+                    </div>
+                    <div className="w-16 h-16 rounded-full border-4 border-white overflow-hidden bg-white">
+                      <img
+                        src={`${AVATAR_BASE_URL}${encodeURIComponent(inst.to)}`}
+                        alt={inst.to}
+                        crossOrigin="anonymous"
+                        className="w-full h-full object-cover"
+                      />
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-1 min-w-0">
+                    <p className="text-2xl font-bold text-slate-600">
+                      <span className="text-destructive font-black underline decoration-destructive/20 underline-offset-4">
+                        {inst.from}
+                      </span>
+                      {" bayar ke "}
+                      <span className="text-emerald-600 font-black underline decoration-emerald-600/20 underline-offset-4">
+                        {inst.to}
+                      </span>
+                    </p>
+                    <p className="text-xl font-bold text-slate-400 uppercase tracking-widest">
+                      Aggregated Settlement
+                    </p>
+                  </div>
+                </div>
+                <div className="flex flex-col items-end gap-1 shrink-0">
+                  <span className="text-3xl font-black text-primary">
+                    {formatToIDR(inst.amount)}
+                  </span>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="text-center py-20 bg-slate-50 rounded-[40px] border border-dashed border-slate-200">
+              <p className="text-3xl font-black text-slate-400">
+                Gak ada yang perlu ditransfer! 🎉
+              </p>
+              <p className="text-xl font-bold text-slate-400 mt-2">
+                Semua orang sudah lunas/impas.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Rincian Per Orang Section */}
+      <div className="relative z-10 w-full mt-16 px-4">
+        <h3 className="text-3xl font-black text-slate-800 mb-10 flex items-center gap-4">
+          <Users className="w-8 h-8 text-primary" />
+          Rincian Per Orang 📊
+        </h3>
+        <div className="flex flex-col gap-8 w-full">
+          {balances.map((person) => {
+            const diff = person.balance; // totalPaid - totalOwed
+            const isOwed = diff > 0.01;
+            const isLunas = Math.abs(diff) <= 0.01;
+
+            return (
+              <div
+                key={person.name}
+                className="flex flex-col gap-10 p-8 bg-white border border-slate-100 rounded-[50px]"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-8">
+                    <div className="w-28 h-28 rounded-full border-4 border-white overflow-hidden bg-white shrink-0">
+                      <img
+                        src={`${AVATAR_BASE_URL}${encodeURIComponent(person.name)}`}
+                        alt={person.name}
+                        crossOrigin="anonymous"
+                        className="w-full h-full object-cover"
+                      />
+                    </div>
+                    <div className="flex flex-col gap-2">
+                      <p className="text-5xl font-black text-slate-800 tracking-tight">
+                        {person.name}
+                      </p>
+                      <div className="flex items-center gap-6 text-2xl font-bold text-slate-400">
+                        <p>
+                          Bayar:{" "}
+                          <span className="text-slate-600">
+                            {formatToIDR(person.totalPaid)}
+                          </span>
+                        </p>
+                        <div className="w-2 h-2 rounded-full bg-slate-200" />
+                        <p>
+                          Beban:{" "}
+                          <span className="text-slate-600">
+                            {formatToIDR(person.totalOwed)}
+                          </span>
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <p
+                      className={cn(
+                        "text-[16px] font-black uppercase tracking-widest px-6 py-2 rounded-full inline-block mb-2 border",
+                        isLunas
+                          ? "bg-slate-50 text-slate-400 border-slate-100"
+                          : isOwed
+                            ? "bg-emerald-50 text-emerald-600 border-emerald-100"
+                            : "bg-destructive/5 text-destructive border-destructive/10",
+                      )}
+                    >
+                      {isLunas ? "Lunas" : isOwed ? "Terima" : "Bayar"}
+                    </p>
+                    <p
+                      className={cn(
+                        "text-5xl font-black tracking-tighter",
+                        isLunas
+                          ? "text-slate-400"
+                          : isOwed
+                            ? "text-emerald-600"
+                            : "text-destructive",
+                      )}
+                    >
+                      {formatToIDR(Math.abs(diff))}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Detail Rekening Pembayaran Section */}
+      {paymentMethods.length > 0 && (
+        <div className="relative z-10 w-full mt-16 px-4">
+          <div className="space-y-8">
+            <h3 className="text-3xl font-black text-slate-800 flex items-center gap-4">
+              <DollarSign className="w-8 h-8 text-primary" />
+              Detail Rekening Pembayaran 📥
+            </h3>
+            <div className="grid grid-cols-2 gap-6 p-6 bg-slate-50 rounded-[50px] border border-slate-100">
+              {paymentMethods.map((method) => (
+                <div
+                  key={method.id}
+                  className="p-6 bg-white border border-slate-100 rounded-[35px] flex items-center gap-8"
+                >
+                  <div className="w-24 h-24 bg-slate-50 rounded-3xl flex items-center justify-center border border-slate-100 shrink-0 relative overflow-hidden">
+                    {[
+                      "bca",
+                      "bni",
+                      "bri",
+                      "mandiri",
+                      "dana",
+                      "gopay",
+                      "ovo",
+                      "shopeepay",
+                      "jenius",
+                      "linkaja",
+                      "permata",
+                      "danamon",
+                      "bsi",
+                      "btn",
+                      "bank jago",
+                      "seabank",
+                    ].some((kw) =>
+                      method.providerName.toLowerCase().includes(kw),
+                    ) ? (
+                      <img
+                        src={`/img/logo-${method.providerName.toLowerCase()}.png`}
+                        alt={method.providerName}
+                        crossOrigin="anonymous"
+                        className="w-full h-full object-contain p-2"
+                      />
+                    ) : (
+                      <div className="text-primary/40 font-black text-2xl uppercase">
+                        {method.providerName.slice(0, 3)}
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex flex-col gap-1 min-w-0">
+                    <p className="text-lg font-black text-primary uppercase tracking-wider leading-none mb-1">
+                      {method.providerName}
+                    </p>
+                    <p className="text-3xl font-black text-slate-900 tracking-tight leading-none py-1 break-all">
+                      {method.accountNumber || method.phoneNumber}
+                    </p>
+                    <p className="text-xl font-bold text-slate-400 mt-1 truncate">
+                      a.n. {method.accountName}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Footer Brand */}
+      <div className="relative z-10 mt-auto pt-24 pb-8 text-center w-full">
+        <div className="w-full h-px bg-slate-100 mb-10" />
+        <p className="text-slate-600 text-2xl font-bold">
+          Dihitung otomatis dengan cinta oleh{" "}
+          <span className="text-primary font-black">SplitBill</span>
+        </p>
+        <p className="text-primary font-black text-3xl mt-3 tracking-tighter">
+          splitbill.my.id
+        </p>
+      </div>
+    </div>
+  );
+});
+
+SocialSplitLaterReceipt.displayName = "SocialSplitLaterReceipt";

--- a/src/components/splitbill/BillSummary.tsx
+++ b/src/components/splitbill/BillSummary.tsx
@@ -60,10 +60,10 @@ export const BillSummary = ({
   const router = useRouter();
   const dataForCalc = billData
     ? {
-        people: billData.people,
-        expenses: billData.expenses,
-        additionalExpenses: billData.additionalExpenses,
-      }
+      people: billData.people,
+      expenses: billData.expenses,
+      additionalExpenses: billData.additionalExpenses,
+    }
     : undefined;
 
   const { balances, totalSpent, settlementInstructions, badges } =
@@ -256,7 +256,7 @@ export const BillSummary = ({
                   </p>
                   {typeof window !== "undefined" &&
                     new URLSearchParams(window.location.search).get("new") ===
-                      "true" && (
+                    "true" && (
                       <span className="text-[8px] font-black bg-primary text-white px-1.5 py-0.5 rounded-full shadow-sm shadow-primary/20">
                         BARU
                       </span>
@@ -559,7 +559,7 @@ export const BillSummary = ({
         {!showDownload && !isPublic && (
           <div className="absolute inset-x-0 bottom-0 h-24 z-20 flex flex-col items-center justify-end pb-2 mb-0 bg-gradient-to-t from-background via-background/95 to-transparent pointer-events-none">
             <div className="bg-white border border-primary/10 px-3 py-1.5 rounded-full shadow-lg shadow-primary/5 flex items-center gap-1.5 animate-bounce-subtle">
-              <span className="text-xs font-bold text-primary">
+              <span className="text-[10px] font-bold text-primary">
                 Simpan dulu yuk! Biar bisa di share bill Aesthetic kamu 📸
               </span>
             </div>

--- a/src/components/wallet/HistoryTab.tsx
+++ b/src/components/wallet/HistoryTab.tsx
@@ -240,7 +240,7 @@ export const HistoryTab = () => {
   );
 
   return (
-    <div className="space-y-6 pb-20">
+    <div className="space-y-6">
       {/* Tabs and Filter Button */}
       <div className="flex items-center gap-3">
         <div className="flex-1">

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -31,6 +31,6 @@ export const config = {
      * - favicon.ico (favicon file)
      * - img (public images)
      */
-    "/((?!api|_next/static|_next/image|favicon.ico|img).*)",
+    "/((?!api|_next/static|_next/image|favicon.ico|img|sitemap.xml|robots.txt).*)",
   ],
 };


### PR DESCRIPTION
- Fix sitemap reading issues by improving data fetching robustness and URL standardization.
- Exclude sitemap.xml and robots.txt from middleware matcher for direct access.
- Update robots.txt to explicitly allow sitemap and disallow protected routes.
- Adjust Split Later edit bottom sheet height to 80dvh for better mobile responsiveness.
- Shorten hero trust text and improve Split Later settlement sharing UI.
- Cleanup unnecessary bottom paddings in several pages.