### PR TITLE
feat: unify layout & navigation across /blog, /privacy, /terms pages

### DIFF
--- a/src/app/blog/BlogListClient.tsx
+++ b/src/app/blog/BlogListClient.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { Header } from "@/components/layout/Header";
 import { BlogCard } from "@/components/blog/BlogCard";
 import { fetchBlogs } from "@/lib/api/blog";
 import { Blog } from "@/lib/types/blog";
@@ -13,6 +12,8 @@ import { BlogCardSkeleton } from "@/components/blog/BlogCardSkeleton";
 
 import { Footer } from "@/components/layout/Footer";
 import { BlogCTA } from "@/components/blog/BlogCTA";
+import { HomepageFooter } from "@/components/homepage/HomepageFooter";
+import { HomepageNavbar } from "@/components/homepage/HomepageNavbar";
 
 export default function BlogListClient() {
   const [blogs, setBlogs] = useState<Blog[]>([]);
@@ -41,12 +42,12 @@ export default function BlogListClient() {
   );
 
   return (
-    <div className="w-full min-h-screen bg-background pb-0 flex flex-col items-center">
-      <Header title="Blog & Tips" showBackButton sticky />
+    <div className="w-full min-h-screen bg-background pb-0 flex flex-col items-center pt-16 lg:pt-18">
+      <HomepageNavbar />
 
       {/* Hero Banner Section */}
-      <section className="w-full max-w-[600px] relative pt-12 pb-8 px-6">
-        <div className="relative z-10 max-w-[600px] mx-auto text-center">
+      <section className="w-full max-w-[600px] lg:max-w-7xl relative pt-12 pb-8 px-6">
+        <div className="relative z-10 w-full mx-auto text-center">
           <motion.div
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
@@ -77,15 +78,15 @@ export default function BlogListClient() {
       </section>
 
       {/* Main Content */}
-      <main className="w-full max-w-[600px] mx-auto px-4 mt-8 relative z-20 flex-1">
+      <main className="w-full max-w-[600px] lg:max-w-7xl mx-auto px-4 mt-8 relative z-20 flex-1">
         {isLoading ? (
-          <div className="w-full grid grid-cols-1 gap-8">
-            {[1, 2, 3].map((i) => (
+          <div className="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {[1, 2, 3, 4, 5, 6].map((i) => (
               <BlogCardSkeleton key={i} />
             ))}
           </div>
         ) : filteredBlogs.length > 0 ? (
-          <div className="w-full grid grid-cols-1 gap-8">
+          <div className="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
             {filteredBlogs.map((blog, index) => (
               <BlogCard key={blog._id} blog={blog} priority={index === 0} />
             ))}
@@ -111,6 +112,9 @@ export default function BlogListClient() {
 
       {/* CTA Section */}
       <BlogCTA />
+
+      {/* Reusable Footer */}
+      <HomepageFooter />
 
       {/* Mobile Navigation Footer */}
       <Footer />

--- a/src/app/blog/[slug]/BlogDetailClient.tsx
+++ b/src/app/blog/[slug]/BlogDetailClient.tsx
@@ -7,8 +7,10 @@ import { BlogCard } from "@/components/blog/BlogCard";
 import { BlogContent } from "@/components/blog/BlogContent";
 import { Footer } from "@/components/layout/Footer";
 import { BlogCTA } from "@/components/blog/BlogCTA";
+import { HomepageFooter } from "@/components/homepage/HomepageFooter";
 import { formatDate } from "@/lib/utils/index";
 import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
 import { Clock, User, Calendar, Share2, ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { motion } from "framer-motion";
@@ -23,7 +25,7 @@ export default function BlogDetailClient({
   blog,
   recentBlogs = [],
 }: BlogDetailClientProps) {
-  const shareUrl = typeof window !== "undefined" ? window.location.href : "";
+  const shareUrl = `https://splitbill.my.id/blog/${blog.slug}`;
 
   const handleShare = () => {
     if (navigator.share) {
@@ -34,15 +36,80 @@ export default function BlogDetailClient({
       });
     } else {
       navigator.clipboard.writeText(shareUrl);
-      toast.success("Link berhasil disalin!");
+      toast.success("Link berhasil disalin! 🔗", {
+        description: "Tempel di chat atau media sosialmu.",
+      });
     }
   };
 
+  const shareToWhatsApp = () => {
+    const url = encodeURIComponent(shareUrl);
+    const text = encodeURIComponent(`Baca artikel menarik ini: ${blog.title}\n\n`);
+    window.open(`https://api.whatsapp.com/send?text=${text}${url}`, "_blank");
+  };
+
+  const shareToX = () => {
+    const url = encodeURIComponent(shareUrl);
+    const text = encodeURIComponent(`Baca artikel menarik ini: ${blog.title}`);
+    window.open(`https://twitter.com/intent/tweet?text=${text}&url=${url}`, "_blank");
+  };
+
+  const shareToFacebook = () => {
+    const url = encodeURIComponent(shareUrl);
+    window.open(`https://www.facebook.com/sharer/sharer.php?u=${url}`, "_blank");
+  };
+
   return (
-    <div className="min-h-screen bg-white flex flex-col items-center">
+    <div className="min-h-screen bg-white flex flex-col items-center relative">
+      {/* Floating Left Social Share (Desktop only) */}
+      <div className="hidden lg:flex flex-col items-center gap-3.5 fixed left-8 top-1/2 -translate-y-1/2 z-40">
+        {/* WhatsApp */}
+        <button
+          onClick={shareToWhatsApp}
+          className="w-10 h-10 flex items-center justify-center rounded-full bg-[#25D366] text-white hover:bg-[#20ba59] transition-all shadow-md active:scale-95 group relative hover:scale-105"
+          title="Bagikan ke WhatsApp"
+        >
+          <svg className="w-5 h-5 fill-current" viewBox="0 0 24 24">
+            <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L0 24l6.335-1.662c1.746.953 3.71 1.458 5.704 1.459h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413" />
+          </svg>
+          <div className="absolute left-[125%] top-1/2 -translate-y-1/2 bg-slate-900 text-white text-[10px] font-bold py-1.5 px-3 rounded-lg opacity-0 scale-90 group-hover:opacity-100 group-hover:scale-100 transition-all pointer-events-none whitespace-nowrap shadow-md">
+            WhatsApp
+          </div>
+        </button>
+
+        {/* X (formerly Twitter) */}
+        <button
+          onClick={shareToX}
+          className="w-10 h-10 flex items-center justify-center rounded-full bg-black text-white hover:bg-zinc-800 transition-all shadow-md active:scale-95 group relative hover:scale-105"
+          title="Bagikan ke X"
+        >
+          <svg className="w-4 h-4 fill-current" viewBox="0 0 24 24">
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+          </svg>
+          <div className="absolute left-[125%] top-1/2 -translate-y-1/2 bg-slate-900 text-white text-[10px] font-bold py-1.5 px-3 rounded-lg opacity-0 scale-90 group-hover:opacity-100 group-hover:scale-100 transition-all pointer-events-none whitespace-nowrap shadow-md">
+            Twitter / X
+          </div>
+        </button>
+
+        {/* Facebook */}
+        <button
+          onClick={shareToFacebook}
+          className="w-10 h-10 flex items-center justify-center rounded-full bg-[#1877F2] text-white hover:bg-[#166fe5] transition-all shadow-md active:scale-95 group relative hover:scale-105"
+          title="Bagikan ke Facebook"
+        >
+          <svg className="w-5 h-5 fill-current" viewBox="0 0 24 24">
+            <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
+          </svg>
+          <div className="absolute left-[125%] top-1/2 -translate-y-1/2 bg-slate-900 text-white text-[10px] font-bold py-1.5 px-3 rounded-lg opacity-0 scale-90 group-hover:opacity-100 group-hover:scale-100 transition-all pointer-events-none whitespace-nowrap shadow-md">
+            Facebook
+          </div>
+        </button>
+      </div>
+
       <Header
         sticky
         showBackButton
+        wide
         rightContent={
           <button
             onClick={handleShare}
@@ -53,123 +120,151 @@ export default function BlogDetailClient({
         }
       />
 
-      {/* Article Hero */}
-      <section className="relative w-full max-w-[600px] aspect-[4/3] md:aspect-[16/9] min-h-[300px] bg-muted overflow-hidden shadow-soft">
-        <img
-          src={blog.thumbnail || "/img/pwa-banner.png"}
-          alt={blog.thumbnailAlt || blog.title}
-          className="w-full h-full object-cover"
-          loading="eager"
-        />
-        <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent" />
+      {/* Main Content & Sidebar Wrapper */}
+      <div className="w-full max-w-[600px] lg:max-w-7xl mx-auto px-6 pt-0 pb-8 lg:py-8 flex flex-col lg:flex-row gap-8 lg:gap-12 items-start lg:mt-8">
 
-        <div className="absolute bottom-0 left-0 w-full p-6 md:p-8 text-white">
-          <div className="max-w-[600px] mx-auto">
-            <motion.div
-              initial={{ opacity: 0, y: 30 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-            >
-              <Badge className="bg-primary text-white border-none px-4 py-1.5 rounded-full text-xs font-bold uppercase tracking-widest mb-4">
-                {blog.category}
-              </Badge>
-              <h1 className="text-3xl font-black mb-4 leading-tight tracking-tight">
-                {blog.title}
-              </h1>
+        {/* Left Column: Hero Banner Image & Main Content */}
+        <main className="w-full lg:flex-1 flex flex-col gap-6">
+          {/* Article Hero */}
+          <section className="relative w-[calc(100%+48px)] -mx-6 -mt-0 rounded-none lg:w-full lg:mx-0 lg:mt-0 lg:rounded-lg aspect-[4/3] md:aspect-[16/9] min-h-[300px] bg-muted overflow-hidden shadow-soft">
+            <img
+              src={blog.thumbnail || "/img/pwa-banner.png"}
+              alt={blog.thumbnailAlt || blog.title}
+              className="w-full h-full object-cover"
+              loading="eager"
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent" />
 
-              <div className="flex flex-wrap items-center gap-6 text-xs text-white/80 font-medium">
-                <div className="flex items-center gap-2">
-                  <div className="w-7 h-7 rounded-full bg-white/20 flex items-center justify-center">
-                    <User className="w-4 h-4" />
-                  </div>
-                  <span>{blog.author}</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Calendar className="w-4 h-4" />
-                  <span>{formatDate(blog.publishedAt || blog.createdAt)}</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Clock className="w-4 h-4" />
-                  <span>{blog.readTime} mnt baca</span>
-                </div>
-              </div>
-            </motion.div>
-          </div>
-        </div>
-      </section>
-
-      {/* Article Content */}
-      <main className="max-w-[600px] mx-auto p-6">
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.8, delay: 0.2 }}
-        >
-          {/* Lead Paragraph / Excerpt */}
-          <p className="text-lg md:text-xl font-medium text-foreground/80 leading-relaxed mb-12 border-l-4 border-primary pl-6">
-            {blog.excerpt}
-          </p>
-
-          <BlogContent content={blog.content} />
-
-          {/* Tags Section */}
-          {blog.tags && blog.tags.length > 0 && (
-            <div className="mt-10 pt-8 border-t border-border flex flex-wrap gap-2">
-              {blog.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="px-3 py-1 bg-muted rounded-[6px] text-sm font-medium text-muted-foreground hover:bg-secondary hover:text-primary transition-colors cursor-pointer"
+            <div className="absolute bottom-0 left-0 w-full p-6 md:p-8 text-white">
+              <div className="w-full">
+                <motion.div
+                  initial={{ opacity: 0, y: 30 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.6 }}
                 >
-                  #{tag}
-                </span>
-              ))}
-            </div>
-          )}
+                  <Badge className="bg-primary text-white border-none px-4 py-1.5 rounded-full text-xs font-bold uppercase tracking-widest mb-4">
+                    {blog.category}
+                  </Badge>
+                  <h1 className="text-2xl md:text-3xl font-black mb-4 leading-tight tracking-tight">
+                    {blog.title}
+                  </h1>
 
-          {/* Bottom Footer / Navigation */}
-          <div className="mt-8 py-6 border-t border-border flex flex-wrap items-center justify-between gap-6">
-            <div className="flex items-center gap-3">
-              <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center text-primary">
-                <User className="w-5 h-5" />
-              </div>
-              <div className="flex flex-col">
-                <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
-                  Penulis
-                </span>
-                <span className="text-base font-bold text-foreground leading-none">
-                  {blog.author}
-                </span>
+                  <div className="flex flex-wrap items-center gap-6 text-xs text-white/80 font-medium">
+                    <div className="flex items-center gap-2">
+                      <div className="w-7 h-7 rounded-full bg-white/20 flex items-center justify-center">
+                        <User className="w-4 h-4" />
+                      </div>
+                      <span>{blog.author}</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Calendar className="w-4 h-4" />
+                      <span>{formatDate(blog.publishedAt || blog.createdAt)}</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Clock className="w-4 h-4" />
+                      <span>{blog.readTime} mnt baca</span>
+                    </div>
+                  </div>
+                </motion.div>
               </div>
             </div>
+          </section>
 
-            <Link href="/blog">
-              <button className="flex items-center gap-2 text-primary font-bold text-sm hover:underline transition-all">
-                <ArrowLeft className="w-4 h-4" />
-                Kembali ke Blog
-              </button>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.8, delay: 0.2 }}
+          >
+            {/* Lead Paragraph / Excerpt */}
+            <p className="text-lg md:text-xl font-medium text-foreground/80 leading-relaxed mb-12 border-l-4 border-primary pl-6">
+              {blog.excerpt}
+            </p>
+
+            <BlogContent content={blog.content} />
+
+            {/* Tags Section */}
+            {blog.tags && blog.tags.length > 0 && (
+              <div className="mt-10 pt-8 border-t border-border flex flex-wrap gap-2">
+                {blog.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="px-3 py-1 bg-muted rounded-[6px] text-sm font-medium text-muted-foreground hover:bg-secondary hover:text-primary transition-colors cursor-pointer"
+                  >
+                    #{tag}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {/* Bottom Footer / Navigation */}
+            <div className="mt-8 py-6 border-t border-border flex flex-wrap items-center justify-between gap-6">
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center text-primary">
+                  <User className="w-5 h-5" />
+                </div>
+                <div className="flex flex-col">
+                  <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+                    Penulis
+                  </span>
+                  <span className="text-base font-bold text-foreground leading-none">
+                    {blog.author}
+                  </span>
+                </div>
+              </div>
+
+              <Link href="/blog">
+                <button className="flex items-center gap-2 text-primary font-bold text-sm hover:underline transition-all">
+                  <ArrowLeft className="w-4 h-4" />
+                  Kembali ke Blog
+                </button>
+              </Link>
+            </div>
+          </motion.div>
+        </main>
+
+        {/* Right Column: Sidebar */}
+        <aside className="w-full lg:w-[360px] shrink-0 flex flex-col gap-6">
+          {/* Ads Banner CTA to /split-bill */}
+          <div className="w-full bg-gradient-to-br from-slate-50 to-slate-100/50 p-6 rounded-2xl flex flex-col gap-4 relative overflow-hidden">
+            <div className="space-y-2">
+              <div className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-primary/10 text-primary text-[10px] font-bold uppercase tracking-wider">
+                Fitur Populer
+              </div>
+              <h3 className="font-bold text-base text-foreground leading-tight">
+                Bagi Tagihan Lebih Praktis ⚡️
+              </h3>
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                Scan struk belanja & hitung nominal secara otomatis dengan AI. Gratis, cepat, dan akurat.
+              </p>
+            </div>
+            <Link href="/split-bill">
+              <Button className="w-full py-2.5 text-xs font-bold rounded-sm shadow-sm hover:shadow-md transition-all cursor-pointer">
+                Coba Split Bill Sekarang
+              </Button>
             </Link>
           </div>
-        </motion.div>
-      </main>
 
-      {/* Read Next Section */}
-      {recentBlogs.length > 0 && (
-        <section className="w-full max-w-[600px] mx-auto flex flex-col items-center">
-          <div className="w-full p-6">
-            <h2 className="text-2xl font-black mb-8 tracking-tight text-foreground">
-              Baca Artikel Lainnya
-            </h2>
-            <div className="grid grid-cols-1 gap-8">
-              {recentBlogs.map((recentBlog) => (
-                <BlogCard key={recentBlog._id} blog={recentBlog} />
-              ))}
+          {/* Sidebar: Read Next Section */}
+          {recentBlogs.length > 0 && (
+            <div className="w-full bg-gray-50/50 lg:bg-transparent lg:p-0 rounded-3xl">
+              <h2 className="text-xl font-black mb-6 tracking-tight text-foreground">
+                Baca Artikel Lainnya
+              </h2>
+              <div className="flex flex-col gap-6">
+                {recentBlogs.map((recentBlog) => (
+                  <BlogCard key={recentBlog._id} blog={recentBlog} />
+                ))}
+              </div>
             </div>
-          </div>
-        </section>
-      )}
+          )}
+        </aside>
+      </div>
 
       {/* CTA Section */}
       <BlogCTA />
+
+      {/* Reusable Footer */}
+      <HomepageFooter />
 
       {/* Mobile Navigation Footer */}
       <Footer />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -238,19 +238,19 @@ body {
 .blog-content-container h4 {
   color: var(--foreground);
   font-weight: 700;
-  margin-top: 2.5rem;
-  margin-bottom: 1.25rem;
-  line-height: 1.3;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+  line-height: 1.35;
 }
 
-.blog-content-container h1 { font-size: 2.25rem; }
-.blog-content-container h2 { font-size: 1.875rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; }
-.blog-content-container h3 { font-size: 1.5rem; }
-.blog-content-container h4 { font-size: 1.25rem; }
+.blog-content-container h1 { font-size: 1.75rem; }
+.blog-content-container h2 { font-size: 1.4rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; }
+.blog-content-container h3 { font-size: 1.2rem; }
+.blog-content-container h4 { font-size: 1.05rem; }
 
 .blog-content-container p {
-  margin-bottom: 1.5rem;
-  font-size: 1.125rem;
+  margin-bottom: 1.25rem;
+  font-size: 0.975rem;
 }
 
 .blog-content-container ul, 
@@ -272,6 +272,13 @@ body {
   max-width: 100%;
   height: auto;
   box-shadow: 0 10px 30px -10px rgba(0,0,0,0.1);
+}
+
+.blog-content-container hr {
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: 2.5rem 0;
+  opacity: 0.8;
 }
 
 .blog-content-container blockquote {

--- a/src/app/privacy/PrivacyClientPage.tsx
+++ b/src/app/privacy/PrivacyClientPage.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import React from "react";
-import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
+import { HomepageFooter } from "@/components/homepage/HomepageFooter";
+import { HomepageNavbar } from "@/components/homepage/HomepageNavbar";
+import { cn } from "@/lib/utils";
 import {
   ShieldCheck,
   Eye,
@@ -21,161 +23,145 @@ import { motion } from "framer-motion";
 import Link from "next/link";
 import { Badge } from "@/components/ui/Badge";
 
+const sections = [
+  { id: "ringkasan", label: "Ringkasan Kebijakan" },
+  { id: "pasal-1", label: "Pasal 1: Pendahuluan" },
+  { id: "pasal-2", label: "Pasal 2: Dasar Hukum Pemrosesan" },
+  { id: "pasal-3", label: "Pasal 3: Data yang Kami Kumpulkan" },
+  { id: "pasal-4", label: "Pasal 4: Tujuan Penggunaan Data" },
+  { id: "pasal-5", label: "Pasal 5: Pengungkapan Data" },
+  { id: "pasal-6", label: "Pasal 6: Penyimpanan & Retensi" },
+  { id: "pasal-7", label: "Pasal 7: Keamanan Data" },
+  { id: "pasal-8", label: "Pasal 8: Hak-Hak Anda" },
+  { id: "pasal-9", label: "Pasal 9: Kuki (Cookies)" },
+  { id: "pasal-10", label: "Pasal 10: Transfer Lintas Batas" },
+  { id: "pasal-11", label: "Pasal 11: Tautan Pihak Ketiga" },
+  { id: "pasal-12", label: "Pasal 12: Pembaruan Kebijakan" },
+  { id: "pasal-13", label: "Pasal 13: Penyelesaian Sengketa" },
+  { id: "pasal-14", label: "Pasal 14: Informasi Kontak" },
+];
+
 export default function PrivacyClientPage() {
   const lastUpdated = "16 Mei 2026";
+  const [activeSection, setActiveSection] = React.useState("");
+
+  React.useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveSection(entry.target.id);
+          }
+        });
+      },
+      { rootMargin: "-10% 0px -85% 0px" }
+    );
+
+    sections.forEach((s) => {
+      const el = document.getElementById(s.id);
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, []);
 
   return (
-    <div className="min-h-screen bg-white flex flex-col items-center">
-      <Header sticky showBackButton title="Kebijakan Privasi" />
+    <div className="min-h-screen bg-slate-50/50 flex flex-col items-center pt-16 lg:pt-18">
+      <HomepageNavbar />
 
       {/* Main Content Area */}
-      <main className="w-full max-w-[600px] mx-auto px-6 py-12">
-        <motion.div
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-          className="space-y-12 text-[#4b5563] leading-relaxed text-justify"
-        >
-          {/* Header Section */}
-          <div className="space-y-4 mb-10 flex flex-col items-center text-center">
-            <h1 className="text-4xl font-bold text-[#111827] tracking-tight">
-              Kebijakan Privasi
-            </h1>
-            <div className="text-md text-[#4b5563] space-y-1">
-              <p className="font-bold">Split Bill Online</p>
-              <p>https://splitbill.my.id</p>
-              <p className="text-sm italic">Berlaku sejak: 16 Mei 2026</p>
-            </div>
-          </div>
-
-          <div className="border-b border-border w-full" />
-
-          {/* Ringkasan Kebijakan */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151]">
-              Ringkasan Kebijakan
-            </h2>
-            <p>
-              Kebijakan Privasi ini disusun sesuai dengan Undang-Undang Nomor 27
-              Tahun 2022 tentang Pelindungan Data Pribadi (“UU PDP”) dan
-              peraturan perundang-undangan yang berlaku di Republik Indonesia.
-              Dokumen ini menjelaskan secara transparan cara Split Bill Online
-              mengumpulkan, memproses, menyimpan, dan melindungi data pribadi
-              Anda.
-            </p>
-          </div>
-
-          {/* Pasal 1 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 1 -</span>
-              Pendahuluan
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Split Bill Online (selanjutnya disebut "Pengelola", "Kami", atau
-                "Milik Kami") adalah platform layanan pembagian tagihan daring
-                yang dapat diakses melalui{" "}
-                <Link
-                  href="/"
-                  className="text-primary hover:underline font-medium"
+      <main className="w-full max-w-[600px] lg:max-w-7xl mx-auto px-4 sm:px-6 py-4 sm:py-12 flex-1">
+        <div className="flex flex-col lg:flex-row gap-10 items-start">
+          {/* Sticky Sidebar on Desktop */}
+          <aside className="hidden lg:block w-72 shrink-0 sticky top-24 max-h-[calc(100vh-120px)] overflow-y-auto pr-4 border-r border-slate-100">
+            <h4 className="text-xs font-bold uppercase tracking-wider text-slate-400 mb-4 px-2">Daftar Isi</h4>
+            <nav className="space-y-1">
+              {sections.map((section) => (
+                <a
+                  key={section.id}
+                  href={`#${section.id}`}
+                  className={cn(
+                    "block py-2 px-3 text-xs font-semibold rounded-[2px] transition-all border-l-2 text-left",
+                    activeSection === section.id
+                      ? "text-primary border-primary bg-primary/5 pl-4 font-bold"
+                      : "text-slate-500 border-transparent hover:text-primary hover:bg-slate-100/50 hover:border-slate-300"
+                  )}
                 >
-                  https://splitbill.my.id
-                </Link>
-                . Pengelola berkomitmen untuk melindungi privasi dan keamanan
-                data pribadi setiap pengguna layanan ini.
-              </p>
-              <p>
-                Kebijakan Privasi ini merupakan dokumen hukum yang mengikat
-                secara hukum antara Pengelola dan pengguna layanan (selanjutnya
-                disebut "Anda" atau "Subjek Data"). Kebijakan ini menjelaskan:
-              </p>
-              <div className="space-y-2">
-                {[
-                  "jenis data pribadi yang Kami kumpulkan;",
-                  "dasar hukum, tujuan, dan cara penggunaan data pribadi;",
-                  "pihak ketiga yang dapat menerima data pribadi Anda;",
-                  "jangka waktu penyimpanan data pribadi;",
-                  "langkah-langkah keamanan yang Kami terapkan; serta",
-                  "hak-hak Anda sebagai Subjek Data dan cara menggunakannya.",
-                ].map((item, i) => (
-                  <div key={i} className="flex gap-2 pl-4">
-                    <span className="text-[#9ca3af] shrink-0">•</span>
-                    <p>{item}</p>
-                  </div>
-                ))}
+                  {section.label}
+                </a>
+              ))}
+            </nav>
+          </aside>
+
+          {/* Content */}
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+            className="flex-1 space-y-12 text-[#4b5563] leading-relaxed text-justify max-w-none bg-white px-6 py-12 sm:p-14 rounded-lg border border-slate-100"
+          >
+            {/* Header Section */}
+            <div className="space-y-4 mb-10 flex flex-col items-center text-center">
+              <h1 className="text-4xl font-bold text-[#111827] tracking-tight">
+                Kebijakan Privasi
+              </h1>
+              <div className="text-md text-[#4b5563] space-y-1">
+                <p className="font-bold">Split Bill Online</p>
+                <p>https://splitbill.my.id</p>
+                <p className="text-sm italic">Berlaku sejak: 16 Mei 2026</p>
               </div>
+            </div>
+
+            <div className="border-b border-border w-full" />
+
+            {/* Ringkasan Kebijakan */}
+            <div id="ringkasan" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151]">
+                Ringkasan Kebijakan
+              </h2>
               <p>
-                Dengan mengakses atau menggunakan layanan Kami, Anda menyatakan
-                telah membaca, memahami, dan menyetujui seluruh ketentuan dalam
-                Kebijakan Privasi ini. Apabila Anda tidak menyetujui kebijakan
-                ini, Anda dimohon untuk tidak menggunakan layanan Kami.
+                Kebijakan Privasi ini disusun sesuai dengan Undang-Undang Nomor 27
+                Tahun 2022 tentang Pelindungan Data Pribadi (“UU PDP”) dan
+                peraturan perundang-undangan yang berlaku di Republik Indonesia.
+                Dokumen ini menjelaskan secara transparan cara Split Bill Online
+                mengumpulkan, memproses, menyimpan, dan melindungi data pribadi
+                Anda.
               </p>
             </div>
-          </div>
 
-          {/* Pasal 2 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 2 -</span>
-              Dasar Hukum Pemrosesan Data Pribadi
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Pemrosesan data pribadi oleh Pengelola dilaksanakan berdasarkan
-                ketentuan peraturan perundang-undangan berikut:
-              </p>
-              <div className="space-y-2">
-                {[
-                  'Undang-Undang Nomor 27 Tahun 2022 tentang Pelindungan Data Pribadi ("UU PDP");',
-                  'Undang-Undang Nomor 11 Tahun 2008 tentang Informasi dan Transaksi Elektronik sebagaimana diubah dengan Undang-Undang Nomor 19 Tahun 2016 ("UU ITE");',
-                  'Peraturan Pemerintah Nomor 71 Tahun 2019 tentang Penyelenggaraan Sistem dan Transaksi Elektronik ("PP PSTE");',
-                  "Peraturan Menteri Komunikasi dan Informatika Nomor 20 Tahun 2016 tentang Perlindungan Data Pribadi dalam Sistem Elektronik; serta",
-                  "peraturan perundang-undangan lain yang berlaku dan berkaitan dengan penyelenggaraan sistem elektronik di wilayah hukum Republik Indonesia.",
-                ].map((item, i) => (
-                  <div key={i} className="flex gap-2 pl-4">
-                    <span className="text-[#9ca3af] shrink-0">•</span>
-                    <p>{item}</p>
-                  </div>
-                ))}
-              </div>
-              <p>
-                Pemrosesan data pribadi dilakukan atas dasar persetujuan
-                eksplisit Anda selaku Subjek Data, sebagaimana dimaksud dalam
-                Pasal 20 UU PDP. Persetujuan tersebut diberikan pada saat Anda
-                mendaftarkan akun dan/atau menggunakan layanan Kami untuk
-                pertama kalinya.
-              </p>
-              <p>
-                Dalam hal tertentu, pemrosesan data pribadi juga dapat dilakukan
-                untuk memenuhi kewajiban hukum Pengelola, melindungi kepentingan
-                vital Anda, atau untuk kepentingan yang sah berdasarkan
-                keseimbangan kepentingan (legitimate interest) yang tidak
-                mengabaikan hak-hak dasar Anda.
-              </p>
-            </div>
-          </div>
-
-          {/* Pasal 3 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 3 -</span>
-              Data Pribadi yang Kami Kumpulkan
-            </h2>
-            <div className="space-y-6">
-              <div className="space-y-3">
-                <h3 className="font-bold text-[#374151]">
-                  3.1 Data Identitas dan Akun
-                </h3>
+            {/* Pasal 1 */}
+            <div id="pasal-1" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 1 -</span>
+                Pendahuluan
+              </h2>
+              <div className="space-y-4">
                 <p>
-                  Ketika Anda mendaftarkan akun melalui mekanisme Google OAuth
-                  2.0, Kami mengumpulkan data sebagai berikut:
+                  Split Bill Online (selanjutnya disebut "Pengelola", "Kami", atau
+                  "Milik Kami") adalah platform layanan pembagian tagihan daring
+                  yang dapat diakses melalui{" "}
+                  <Link
+                    href="/"
+                    className="text-primary hover:underline font-medium"
+                  >
+                    https://splitbill.my.id
+                  </Link>
+                  . Pengelola berkomitmen untuk melindungi privasi dan keamanan
+                  data pribadi setiap pengguna layanan ini.
+                </p>
+                <p>
+                  Kebijakan Privasi ini merupakan dokumen hukum yang mengikat
+                  secara hukum antara Pengelola dan pengguna layanan (selanjutnya
+                  disebut "Anda" atau "Subjek Data"). Kebijakan ini menjelaskan:
                 </p>
                 <div className="space-y-2">
                   {[
-                    "Nama lengkap, sebagaimana terdaftar pada akun Google Anda;",
-                    "Alamat surat elektronik (surel) yang aktif;",
-                    "Foto profil akun Google Anda (jika tersedia dan telah disetel sebagai publik oleh Anda).",
+                    "jenis data pribadi yang Kami kumpulkan;",
+                    "dasar hukum, tujuan, dan cara penggunaan data pribadi;",
+                    "pihak ketiga yang dapat menerima data pribadi Anda;",
+                    "jangka waktu penyimpanan data pribadi;",
+                    "langkah-langkah keamanan yang Kami terapkan; serta",
+                    "hak-hak Anda sebagai Subjek Data dan cara menggunakannya.",
                   ].map((item, i) => (
                     <div key={i} className="flex gap-2 pl-4">
                       <span className="text-[#9ca3af] shrink-0">•</span>
@@ -184,553 +170,633 @@ export default function PrivacyClientPage() {
                   ))}
                 </div>
                 <p>
-                  Data tersebut digunakan semata-mata untuk keperluan
-                  autentikasi, identifikasi akun, dan personalisasi tampilan
-                  layanan. Kami tidak memiliki akses terhadap kata sandi
-                  (password) akun Google Anda.
-                </p>
-              </div>
-
-              <div className="space-y-3">
-                <h3 className="font-bold text-[#374151]">
-                  3.2 Data Transaksi dan Konten
-                </h3>
-                <p>
-                  Dalam rangka penyediaan fitur utama layanan Kami, Kami
-                  mengumpulkan:
-                </p>
-                <div className="space-y-2">
-                  {[
-                    "Gambar struk, nota, atau bukti pembayaran yang Anda unggah secara sukarela untuk diproses melalui fitur OCR (Optical Character Recognition) berbasis kecerdasan buatan;",
-                    "Rincian tagihan dan pengeluaran yang Anda masukkan secara manual, termasuk nominal, deskripsi, dan kategori transaksi;",
-                    "Daftar kontak atau nama teman yang Anda tambahkan dalam sesi pembagian tagihan;",
-                    "Catatan pengeluaran yang disimpan dalam fitur Dompet (Wallet);",
-                    "Target tabungan bersama yang dibuat dalam fitur Tujuan Bersama (Shared Goals).",
-                  ].map((item, i) => (
-                    <div key={i} className="flex gap-2 pl-4">
-                      <span className="text-[#9ca3af] shrink-0">•</span>
-                      <p>{item}</p>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              <div className="space-y-3">
-                <h3 className="font-bold text-[#374151]">
-                  3.3 Data Teknis yang Dikumpulkan Secara Otomatis
-                </h3>
-                <p>
-                  Secara otomatis, Kami mengumpulkan data teknis berikut ketika
-                  Anda mengakses Situs:
-                </p>
-                <div className="space-y-2">
-                  {[
-                    "Alamat protokol internet (IP address);",
-                    "Jenis dan versi peramban (browser) yang digunakan;",
-                    "Sistem operasi dan jenis perangkat;",
-                    "Halaman yang dikunjungi dan durasi kunjungan;",
-                    "Data yang dikumpulkan melalui kuki (cookies) dan teknologi serupa.",
-                  ].map((item, i) => (
-                    <div key={i} className="flex gap-2 pl-4">
-                      <span className="text-[#9ca3af] shrink-0">•</span>
-                      <p>{item}</p>
-                    </div>
-                  ))}
-                </div>
-                <p>
-                  Data teknis tersebut digunakan untuk keperluan analisis
-                  kinerja sistem, peningkatan pengalaman pengguna, serta
-                  pendeteksian dan pencegahan aktivitas yang mencurigakan atau
-                  tidak sah.
+                  Dengan mengakses atau menggunakan layanan Kami, Anda menyatakan
+                  telah membaca, memahami, dan menyetujui seluruh ketentuan dalam
+                  Kebijakan Privasi ini. Apabila Anda tidak menyetujui kebijakan
+                  ini, Anda dimohon untuk tidak menggunakan layanan Kami.
                 </p>
               </div>
             </div>
-          </div>
 
-          {/* Pasal 4 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 4 -</span>
-              Tujuan dan Dasar Penggunaan Data Pribadi
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Kami memproses data pribadi Anda hanya untuk tujuan yang telah
-                ditetapkan sebelumnya dan berdasarkan persetujuan yang sah.
-                Tujuan pemrosesan meliputi:
-              </p>
-              <div className="space-y-2">
-                {[
-                  "Autentikasi dan pengelolaan akun pengguna, termasuk pemberian akses ke fitur-fitur layanan;",
-                  "Pemrosesan gambar struk secara otomatis menggunakan teknologi Google Generative AI untuk mengekstraksi informasi nominal dan data transaksi;",
-                  "Pengelolaan dasbor keuangan pribadi, penerbitan faktur digital, dan fasilitasi kolaborasi antar pengguna;",
-                  "Pemeliharaan dan peningkatan akurasi sistem kecerdasan buatan serta pengoptimalan antarmuka pengguna Situs;",
-                  "Komunikasi dengan Anda, termasuk penyampaian pemberitahuan layanan, pembaruan fitur, dan tanggapan atas pertanyaan atau keluhan;",
-                  "Pendeteksian dan pencegahan penipuan, penyalahgunaan layanan, atau pelanggaran terhadap Syarat dan Ketentuan Layanan;",
-                  "Pemenuhan kewajiban hukum, termasuk pemenuhan perintah pengadilan atau instruksi otoritas berwenang berdasarkan ketentuan peraturan perundang-undangan yang berlaku.",
-                ].map((item, i) => (
-                  <div key={i} className="flex gap-2 pl-4">
-                    <span className="text-[#9ca3af] shrink-0">•</span>
-                    <p>{item}</p>
+            {/* Pasal 2 */}
+            <div id="pasal-2" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 2 -</span>
+                Dasar Hukum Pemrosesan Data Pribadi
+              </h2>
+              <div className="space-y-4">
+                <p>
+                  Pemrosesan data pribadi oleh Pengelola dilaksanakan berdasarkan
+                  ketentuan peraturan perundang-undangan berikut:
+                </p>
+                <div className="space-y-2">
+                  {[
+                    'Undang-Undang Nomor 27 Tahun 2022 tentang Pelindungan Data Pribadi ("UU PDP");',
+                    'Undang-Undang Nomor 11 Tahun 2008 tentang Informasi dan Transaksi Elektronik sebagaimana diubah dengan Undang-Undang Nomor 19 Tahun 2016 ("UU ITE");',
+                    'Peraturan Pemerintah Nomor 71 Tahun 2019 tentang Penyelenggaraan Sistem dan Transaksi Elektronik ("PP PSTE");',
+                    "Peraturan Menteri Komunikasi dan Informatika Nomor 20 Tahun 2016 tentang Perlindungan Data Pribadi dalam Sistem Elektronik; serta",
+                    "peraturan perundang-undangan lain yang berlaku dan berkaitan dengan penyelenggaraan sistem elektronik di wilayah hukum Republik Indonesia.",
+                  ].map((item, i) => (
+                    <div key={i} className="flex gap-2 pl-4">
+                      <span className="text-[#9ca3af] shrink-0">•</span>
+                      <p>{item}</p>
+                    </div>
+                  ))}
+                </div>
+                <p>
+                  Pemrosesan data pribadi dilakukan atas dasar persetujuan
+                  eksplisit Anda selaku Subjek Data, sebagaimana dimaksud dalam
+                  Pasal 20 UU PDP. Persetujuan tersebut diberikan pada saat Anda
+                  mendaftarkan akun dan/atau menggunakan layanan Kami untuk
+                  pertama kalinya.
+                </p>
+                <p>
+                  Dalam hal tertentu, pemrosesan data pribadi juga dapat dilakukan
+                  untuk memenuhi kewajiban hukum Pengelola, melindungi kepentingan
+                  vital Anda, atau untuk kepentingan yang sah berdasarkan
+                  keseimbangan kepentingan (legitimate interest) yang tidak
+                  mengabaikan hak-hak dasar Anda.
+                </p>
+              </div>
+            </div>
+
+            {/* Pasal 3 */}
+            <div id="pasal-3" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 3 -</span>
+                Data Pribadi yang Kami Kumpulkan
+              </h2>
+              <div className="space-y-6">
+                <div className="space-y-3">
+                  <h3 className="font-bold text-[#374151]">
+                    3.1 Data Identitas dan Akun
+                  </h3>
+                  <p>
+                    Ketika Anda mendaftarkan akun melalui mekanisme Google OAuth
+                    2.0, Kami mengumpulkan data sebagai berikut:
+                  </p>
+                  <div className="space-y-2">
+                    {[
+                      "Nama lengkap, sebagaimana terdaftar pada akun Google Anda;",
+                      "Alamat surat elektronik (surel) yang aktif;",
+                      "Foto profil akun Google Anda (jika tersedia dan telah disetel sebagai publik oleh Anda).",
+                    ].map((item, i) => (
+                      <div key={i} className="flex gap-2 pl-4">
+                        <span className="text-[#9ca3af] shrink-0">•</span>
+                        <p>{item}</p>
+                      </div>
+                    ))}
                   </div>
-                ))}
+                  <p>
+                    Data tersebut digunakan semata-mata untuk keperluan
+                    autentikasi, identifikasi akun, dan personalisasi tampilan
+                    layanan. Kami tidak memiliki akses terhadap kata sandi
+                    (password) akun Google Anda.
+                  </p>
+                </div>
+
+                <div className="space-y-3">
+                  <h3 className="font-bold text-[#374151]">
+                    3.2 Data Transaksi dan Konten
+                  </h3>
+                  <p>
+                    Dalam rangka penyediaan fitur utama layanan Kami, Kami
+                    mengumpulkan:
+                  </p>
+                  <div className="space-y-2">
+                    {[
+                      "Gambar struk, nota, atau bukti pembayaran yang Anda unggah secara sukarela untuk diproses melalui fitur OCR (Optical Character Recognition) berbasis kecerdasan buatan;",
+                      "Rincian tagihan dan pengeluaran yang Anda masukkan secara manual, termasuk nominal, deskripsi, dan kategori transaksi;",
+                      "Daftar kontak atau nama teman yang Anda tambahkan dalam sesi pembagian tagihan;",
+                      "Catatan pengeluaran yang disimpan dalam fitur Dompet (Wallet);",
+                      "Target tabungan bersama yang dibuat dalam fitur Tujuan Bersama (Shared Goals).",
+                    ].map((item, i) => (
+                      <div key={i} className="flex gap-2 pl-4">
+                        <span className="text-[#9ca3af] shrink-0">•</span>
+                        <p>{item}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="space-y-3">
+                  <h3 className="font-bold text-[#374151]">
+                    3.3 Data Teknis yang Dikumpulkan Secara Otomatis
+                  </h3>
+                  <p>
+                    Secara otomatis, Kami mengumpulkan data teknis berikut ketika
+                    Anda mengakses Situs:
+                  </p>
+                  <div className="space-y-2">
+                    {[
+                      "Alamat protokol internet (IP address);",
+                      "Jenis dan versi peramban (browser) yang digunakan;",
+                      "Sistem operasi dan jenis perangkat;",
+                      "Halaman yang dikunjungi dan durasi kunjungan;",
+                      "Data yang dikumpulkan melalui kuki (cookies) dan teknologi serupa.",
+                    ].map((item, i) => (
+                      <div key={i} className="flex gap-2 pl-4">
+                        <span className="text-[#9ca3af] shrink-0">•</span>
+                        <p>{item}</p>
+                      </div>
+                    ))}
+                  </div>
+                  <p>
+                    Data teknis tersebut digunakan untuk keperluan analisis
+                    kinerja sistem, peningkatan pengalaman pengguna, serta
+                    pendeteksian dan pencegahan aktivitas yang mencurigakan atau
+                    tidak sah.
+                  </p>
+                </div>
               </div>
-              <p>
-                Kami tidak akan memproses data pribadi Anda untuk tujuan selain
-                yang tercantum di atas tanpa terlebih dahulu memperoleh
-                persetujuan baru dari Anda, kecuali diwajibkan oleh peraturan
-                perundang-undangan.
-              </p>
             </div>
-          </div>
 
-          {/* Pasal 5 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 5 -</span>
-              Pengungkapan Data kepada Pihak Ketiga
-            </h2>
-            <div className="space-y-6">
-              <p>
-                Kami menegaskan bahwa Kami tidak menjual, menyewakan, atau
-                memperdagangkan data pribadi Anda kepada pihak ketiga untuk
-                kepentingan komersial. Pengungkapan data pribadi hanya dilakukan
-                dalam kondisi-kondisi berikut:
-              </p>
+            {/* Pasal 4 */}
+            <div id="pasal-4" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 4 -</span>
+                Tujuan dan Dasar Penggunaan Data Pribadi
+              </h2>
+              <div className="space-y-4">
+                <p>
+                  Kami memproses data pribadi Anda hanya untuk tujuan yang telah
+                  ditetapkan sebelumnya dan berdasarkan persetujuan yang sah.
+                  Tujuan pemrosesan meliputi:
+                </p>
+                <div className="space-y-2">
+                  {[
+                    "Autentikasi dan pengelolaan akun pengguna, termasuk pemberian akses ke fitur-fitur layanan;",
+                    "Pemrosesan gambar struk secara otomatis menggunakan teknologi Google Generative AI untuk mengekstraksi informasi nominal dan data transaksi;",
+                    "Pengelolaan dasbor keuangan pribadi, penerbitan faktur digital, dan fasilitasi kolaborasi antar pengguna;",
+                    "Pemeliharaan dan peningkatan akurasi sistem kecerdasan buatan serta pengoptimalan antarmuka pengguna Situs;",
+                    "Komunikasi dengan Anda, termasuk penyampaian pemberitahuan layanan, pembaruan fitur, dan tanggapan atas pertanyaan atau keluhan;",
+                    "Pendeteksian dan pencegahan penipuan, penyalahgunaan layanan, atau pelanggaran terhadap Syarat dan Ketentuan Layanan;",
+                    "Pemenuhan kewajiban hukum, termasuk pemenuhan perintah pengadilan atau instruksi otoritas berwenang berdasarkan ketentuan peraturan perundang-undangan yang berlaku.",
+                  ].map((item, i) => (
+                    <div key={i} className="flex gap-2 pl-4">
+                      <span className="text-[#9ca3af] shrink-0">•</span>
+                      <p>{item}</p>
+                    </div>
+                  ))}
+                </div>
+                <p>
+                  Kami tidak akan memproses data pribadi Anda untuk tujuan selain
+                  yang tercantum di atas tanpa terlebih dahulu memperoleh
+                  persetujuan baru dari Anda, kecuali diwajibkan oleh peraturan
+                  perundang-undangan.
+                </p>
+              </div>
+            </div>
 
-              <div className="space-y-3">
-                <h3 className="font-bold text-[#374151]">
-                  5.1 Penyedia Layanan Teknis (Prosesor Data)
-                </h3>
+            {/* Pasal 5 */}
+            <div id="pasal-5" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 5 -</span>
+                Pengungkapan Data kepada Pihak Ketiga
+              </h2>
+              <div className="space-y-6">
+                <p>
+                  Kami menegaskan bahwa Kami tidak menjual, menyewakan, atau
+                  memperdagangkan data pribadi Anda kepada pihak ketiga untuk
+                  kepentingan komersial. Pengungkapan data pribadi hanya dilakukan
+                  dalam kondisi-kondisi berikut:
+                </p>
+
+                <div className="space-y-3">
+                  <h3 className="font-bold text-[#374151]">
+                    5.1 Penyedia Layanan Teknis (Prosesor Data)
+                  </h3>
+                  <div className="space-y-3 pl-4">
+                    <p>
+                      <strong className="text-[#111827]">
+                        a. Google Cloud Platform
+                      </strong>{" "}
+                      - Digunakan untuk penyimpanan data terenkripsi dan
+                      infrastruktur komputasi awan yang mendukung operasional
+                      Situs.
+                    </p>
+                    <p>
+                      <strong className="text-[#111827]">
+                        b. Google Generative AI (Gemini API)
+                      </strong>{" "}
+                      - Digunakan untuk pemrosesan gambar struk dan ekstraksi teks
+                      menggunakan teknologi kecerdasan buatan. Data yang dikirim
+                      ke layanan ini diproses sesuai dengan kebijakan privasi dan
+                      ketentuan layanan Google.
+                    </p>
+                  </div>
+                  <p>
+                    Seluruh penyedia layanan pihak ketiga yang bekerja sama dengan
+                    Kami diwajibkan mematuhi standar keamanan data yang setara
+                    atau lebih tinggi daripada yang Kami terapkan, serta tunduk
+                    pada perjanjian kerahasiaan dan pemrosesan data yang sah.
+                  </p>
+                </div>
+
+                <div className="space-y-3">
+                  <h3 className="font-bold text-[#374151]">
+                    5.2 Pengungkapan Berdasarkan Kewajiban Hukum
+                  </h3>
+                  <p>
+                    Kami dapat mengungkapkan data pribadi Anda kepada pihak yang
+                    berwenang apabila diwajibkan oleh hukum yang berlaku, termasuk
+                    berdasarkan perintah pengadilan, putusan arbitrase, atau
+                    permintaan resmi dari instansi pemerintah yang berwenang.
+                    Dalam situasi demikian, Kami akan berupaya memberitahu Anda
+                    terlebih dahulu sepanjang ketentuan hukum mengizinkan hal
+                    tersebut.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Pasal 6 */}
+            <div id="pasal-6" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 6 -</span>
+                Penyimpanan dan Retensi Data Pribadi
+              </h2>
+              <div className="space-y-4">
+                <p>
+                  Data pribadi Anda disimpan di server yang berlokasi di wilayah
+                  yang dikelola oleh Google Cloud Platform dengan standar keamanan
+                  internasional. Kami menerapkan kebijakan retensi data sebagai
+                  berikut:
+                </p>
+                <div className="space-y-2">
+                  {[
+                    "Data akun aktif disimpan selama akun Anda aktif digunakan atau diperlukan untuk penyediaan layanan;",
+                    "Setelah akun dihapus atas permintaan Anda, data pribadi akan dihapus secara permanen dalam jangka waktu paling lama 30 (tiga puluh) hari kalender sejak permintaan diterima dan diverifikasi;",
+                    "Data yang diwajibkan untuk disimpan berdasarkan ketentuan peraturan perundang-undangan yang berlaku akan tetap disimpan sesuai jangka waktu yang ditetapkan oleh regulasi terkait;",
+                    "Log teknis dan data anonim dapat disimpan lebih lama untuk keperluan keamanan sistem dan analisis performa.",
+                  ].map((item, i) => (
+                    <div key={i} className="flex gap-2 pl-4">
+                      <span className="text-[#9ca3af] shrink-0">•</span>
+                      <p>{item}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {/* Pasal 7 */}
+            <div id="pasal-7" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 7 -</span>
+                Keamanan Data Pribadi
+              </h2>
+              <div className="space-y-4">
+                <p>
+                  Kami menerapkan langkah-langkah teknis dan organisasional yang
+                  layak untuk melindungi data pribadi Anda dari akses yang tidak
+                  sah, pengungkapan, perubahan, atau pemusnahan. Langkah-langkah
+                  tersebut meliputi:
+                </p>
+                <div className="space-y-2">
+                  {[
+                    "Enkripsi data selama transmisi menggunakan protokol SSL/TLS (Secure Socket Layer/Transport Layer Security) dengan standar minimum TLS 1.2;",
+                    "Enkripsi data saat penyimpanan (at rest encryption) pada infrastruktur Google Cloud Platform;",
+                    "Pembatasan akses ke data pribadi hanya kepada personel yang membutuhkan akses tersebut untuk menjalankan tugasnya (prinsip need-to-know);",
+                    "Pemantauan sistem secara berkala untuk mendeteksi potensi kerentanan keamanan;",
+                    "Penggunaan mekanisme autentikasi dua faktor melalui layanan Google OAuth 2.0.",
+                  ].map((item, i) => (
+                    <div key={i} className="flex gap-2 pl-4">
+                      <span className="text-[#9ca3af] shrink-0">•</span>
+                      <p>{item}</p>
+                    </div>
+                  ))}
+                </div>
+                <p>
+                  Meskipun Kami berupaya semaksimal mungkin untuk melindungi data
+                  pribadi Anda, tidak ada sistem keamanan yang dapat menjamin
+                  perlindungan mutlak. Anda juga bertanggung jawab untuk menjaga
+                  kerahasiaan akses ke akun Anda.
+                </p>
+              </div>
+            </div>
+
+            {/* Pasal 8 */}
+            <div id="pasal-8" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 8 -</span>
+                Hak-Hak Anda sebagai Subjek Data
+              </h2>
+              <div className="space-y-6">
+                <p>
+                  Sesuai dengan ketentuan Undang-Undang Nomor 27 Tahun 2022
+                  tentang Pelindungan Data Pribadi, Anda memiliki hak-hak berikut
+                  yang dapat Anda gunakan kapan saja:
+                </p>
+
+                <div className="space-y-2">
+                  <h4 className="font-bold text-[#374151]">
+                    Hak Informasi (Pasal 8 UU PDP)
+                  </h4>
+                  <p>
+                    Anda berhak mendapatkan informasi yang jelas dan transparan
+                    mengenai identitas Pengelola, tujuan pemrosesan data pribadi,
+                    periode retensi, serta hak-hak Anda.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <h4 className="font-bold text-[#374151]">
+                    Hak Akses (Pasal 9 UU PDP)
+                  </h4>
+                  <p>
+                    Anda berhak memperoleh salinan data pribadi yang Kami miliki
+                    tentang Anda, beserta informasi mengenai cara data tersebut
+                    diproses.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <h4 className="font-bold text-[#374151]">
+                    Hak Perbaikan (Pasal 10 UU PDP)
+                  </h4>
+                  <p>
+                    Anda berhak meminta perbaikan atas data pribadi yang tidak
+                    akurat, tidak lengkap, atau yang sudah tidak relevan.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <h4 className="font-bold text-[#374151]">
+                    Hak Penghapusan (Pasal 11 UU PDP)
+                  </h4>
+                  <p>
+                    Anda berhak meminta penghapusan data pribadi Anda ("hak untuk
+                    dilupakan") dalam kondisi-kondisi tertentu sebagaimana diatur
+                    dalam UU PDP.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <h4 className="font-bold text-[#374151]">
+                    Hak Pembatasan Pemrosesan (Pasal 12 UU PDP)
+                  </h4>
+                  <p>
+                    Anda berhak meminta pembatasan atas pemrosesan data pribadi
+                    Anda dalam kondisi tertentu, misalnya selama sengketa mengenai
+                    keakuratan data sedang diselesaikan.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <h4 className="font-bold text-[#374151]">
+                    Hak Portabilitas Data (Pasal 13 UU PDP)
+                  </h4>
+                  <p>
+                    Anda berhak menerima data pribadi Anda dalam format yang
+                    terstruktur, umum digunakan, dan dapat dibaca oleh mesin,
+                    serta berhak untuk mentransfer data tersebut kepada pengendali
+                    data lain.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <h4 className="font-bold text-[#374151]">
+                    Hak Penarikan Persetujuan (Pasal 20 UU PDP)
+                  </h4>
+                  <p>
+                    Anda berhak menarik kembali persetujuan yang telah Anda
+                    berikan kapan saja, tanpa mengurangi keabsahan pemrosesan yang
+                    telah dilakukan berdasarkan persetujuan sebelum penarikan.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <h4 className="font-bold text-[#374151]">
+                    Hak untuk Mengajukan Keberatan (Pasal 14 UU PDP)
+                  </h4>
+                  <p>
+                    Anda berhak mengajukan keberatan atas pemrosesan data pribadi
+                    Anda, termasuk pemrosesan untuk kepentingan pemasaran langsung
+                    atau pengambilan keputusan otomatis yang berdampak signifikan
+                    terhadap Anda.
+                  </p>
+                </div>
+
+                <div className="space-y-3">
+                  <h4 className="font-bold text-[#374151]">
+                    Cara Menggunakan Hak Anda
+                  </h4>
+                  <p>
+                    Untuk menggunakan hak-hak tersebut di atas, Anda dapat
+                    mengajukan permintaan tertulis kepada Kami melalui surel ke{" "}
+                    <a
+                      href="mailto:legal@splitbill.my.id"
+                      className="text-primary font-bold hover:underline"
+                    >
+                      legal@splitbill.my.id
+                    </a>
+                    . Kami akan merespons permintaan Anda dalam jangka waktu
+                    paling lama 14 (empat belas) hari kerja sejak permintaan
+                    diterima. Untuk keperluan penghapusan akun, Kami akan
+                    menyelesaikan proses tersebut dalam jangka waktu paling lama
+                    30 (tiga puluh) hari kalender. Kami dapat meminta verifikasi
+                    identitas Anda sebelum memproses permintaan guna memastikan
+                    keamanan data Anda.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Pasal 9 */}
+            <div id="pasal-9" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 9 -</span>
+                Penggunaan Kuki (Cookies)
+              </h2>
+              <div className="space-y-4">
+                <p>
+                  Situs Kami menggunakan kuki dan teknologi pelacakan serupa untuk
+                  meningkatkan fungsionalitas dan pengalaman pengguna. Jenis-jenis
+                  kuki yang Kami gunakan adalah sebagai berikut:
+                </p>
                 <div className="space-y-3 pl-4">
                   <p>
-                    <strong className="text-[#111827]">
-                      a. Google Cloud Platform
-                    </strong>{" "}
-                    - Digunakan untuk penyimpanan data terenkripsi dan
-                    infrastruktur komputasi awan yang mendukung operasional
-                    Situs.
+                    <strong className="text-[#111827]">Kuki Esensial:</strong>{" "}
+                    Kuki yang mutlak diperlukan untuk fungsi dasar Situs, seperti
+                    pemeliharaan sesi autentikasi. Kuki ini tidak dapat
+                    dinonaktifkan.
                   </p>
                   <p>
-                    <strong className="text-[#111827]">
-                      b. Google Generative AI (Gemini API)
-                    </strong>{" "}
-                    - Digunakan untuk pemrosesan gambar struk dan ekstraksi teks
-                    menggunakan teknologi kecerdasan buatan. Data yang dikirim
-                    ke layanan ini diproses sesuai dengan kebijakan privasi dan
-                    ketentuan layanan Google.
+                    <strong className="text-[#111827]">Kuki Fungsional:</strong>{" "}
+                    Kuki yang digunakan untuk menyimpan preferensi pengguna,
+                    seperti pilihan bahasa dan pengaturan tampilan.
+                  </p>
+                  <p>
+                    <strong className="text-[#111827]">Kuki Analitik:</strong>{" "}
+                    Kuki yang digunakan untuk mengumpulkan data anonim mengenai
+                    penggunaan Situs guna membantu Kami memahami pola penggunaan
+                    dan meningkatkan layanan.
                   </p>
                 </div>
                 <p>
-                  Seluruh penyedia layanan pihak ketiga yang bekerja sama dengan
-                  Kami diwajibkan mematuhi standar keamanan data yang setara
-                  atau lebih tinggi daripada yang Kami terapkan, serta tunduk
-                  pada perjanjian kerahasiaan dan pemrosesan data yang sah.
-                </p>
-              </div>
-
-              <div className="space-y-3">
-                <h3 className="font-bold text-[#374151]">
-                  5.2 Pengungkapan Berdasarkan Kewajiban Hukum
-                </h3>
-                <p>
-                  Kami dapat mengungkapkan data pribadi Anda kepada pihak yang
-                  berwenang apabila diwajibkan oleh hukum yang berlaku, termasuk
-                  berdasarkan perintah pengadilan, putusan arbitrase, atau
-                  permintaan resmi dari instansi pemerintah yang berwenang.
-                  Dalam situasi demikian, Kami akan berupaya memberitahu Anda
-                  terlebih dahulu sepanjang ketentuan hukum mengizinkan hal
-                  tersebut.
+                  Anda dapat mengatur preferensi kuki melalui pengaturan peramban
+                  Anda. Namun, menonaktifkan kuki tertentu dapat memengaruhi
+                  fungsi dan pengalaman penggunaan Situs.
                 </p>
               </div>
             </div>
-          </div>
 
-          {/* Pasal 6 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 6 -</span>
-              Penyimpanan dan Retensi Data Pribadi
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Data pribadi Anda disimpan di server yang berlokasi di wilayah
-                yang dikelola oleh Google Cloud Platform dengan standar keamanan
-                internasional. Kami menerapkan kebijakan retensi data sebagai
-                berikut:
-              </p>
-              <div className="space-y-2">
-                {[
-                  "Data akun aktif disimpan selama akun Anda aktif digunakan atau diperlukan untuk penyediaan layanan;",
-                  "Setelah akun dihapus atas permintaan Anda, data pribadi akan dihapus secara permanen dalam jangka waktu paling lama 30 (tiga puluh) hari kalender sejak permintaan diterima dan diverifikasi;",
-                  "Data yang diwajibkan untuk disimpan berdasarkan ketentuan peraturan perundang-undangan yang berlaku akan tetap disimpan sesuai jangka waktu yang ditetapkan oleh regulasi terkait;",
-                  "Log teknis dan data anonim dapat disimpan lebih lama untuk keperluan keamanan sistem dan analisis performa.",
-                ].map((item, i) => (
-                  <div key={i} className="flex gap-2 pl-4">
-                    <span className="text-[#9ca3af] shrink-0">•</span>
-                    <p>{item}</p>
-                  </div>
-                ))}
+            {/* Pasal 10 */}
+            <div id="pasal-10" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 10 -</span>
+                Transfer Data Lintas Batas Negara
+              </h2>
+              <div className="space-y-4">
+                <p>
+                  Dalam rangka penggunaan layanan Google Cloud Platform dan Google
+                  Generative AI, data pribadi Anda dapat ditransfer dan diproses
+                  di server yang berlokasi di luar wilayah Republik Indonesia.
+                  Transfer data tersebut dilakukan sesuai dengan ketentuan Pasal
+                  56 UU PDP dan peraturan pelaksanaannya. Kami memastikan bahwa
+                  setiap transfer data lintas batas negara dilakukan dengan
+                  perlindungan yang memadai, termasuk melalui perjanjian yang
+                  mengharuskan penerima data untuk memberikan tingkat perlindungan
+                  yang setara dengan yang ditetapkan dalam UU PDP. Anda menyetujui
+                  transfer data tersebut dengan menggunakan layanan Kami.
+                </p>
               </div>
             </div>
-          </div>
 
-          {/* Pasal 7 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 7 -</span>
-              Keamanan Data Pribadi
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Kami menerapkan langkah-langkah teknis dan organisasional yang
-                layak untuk melindungi data pribadi Anda dari akses yang tidak
-                sah, pengungkapan, perubahan, atau pemusnahan. Langkah-langkah
-                tersebut meliputi:
-              </p>
-              <div className="space-y-2">
-                {[
-                  "Enkripsi data selama transmisi menggunakan protokol SSL/TLS (Secure Socket Layer/Transport Layer Security) dengan standar minimum TLS 1.2;",
-                  "Enkripsi data saat penyimpanan (at rest encryption) pada infrastruktur Google Cloud Platform;",
-                  "Pembatasan akses ke data pribadi hanya kepada personel yang membutuhkan akses tersebut untuk menjalankan tugasnya (prinsip need-to-know);",
-                  "Pemantauan sistem secara berkala untuk mendeteksi potensi kerentanan keamanan;",
-                  "Penggunaan mekanisme autentikasi dua faktor melalui layanan Google OAuth 2.0.",
-                ].map((item, i) => (
-                  <div key={i} className="flex gap-2 pl-4">
-                    <span className="text-[#9ca3af] shrink-0">•</span>
-                    <p>{item}</p>
-                  </div>
-                ))}
+            {/* Pasal 11 */}
+            <div id="pasal-11" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 11 -</span>
+                Tautan dan Layanan Pihak Ketiga
+              </h2>
+              <div className="space-y-4">
+                <p>
+                  Situs Kami dapat memuat tautan menuju situs web atau layanan
+                  pihak ketiga. Kebijakan Privasi ini tidak berlaku terhadap situs
+                  web atau layanan pihak ketiga tersebut. Kami tidak bertanggung
+                  jawab atas praktik privasi atau konten dari situs web atau
+                  layanan pihak ketiga tersebut. Kami mendorong Anda untuk membaca
+                  dan memahami kebijakan privasi dari setiap situs web atau
+                  layanan pihak ketiga yang Anda kunjungi atau gunakan.
+                </p>
               </div>
-              <p>
-                Meskipun Kami berupaya semaksimal mungkin untuk melindungi data
-                pribadi Anda, tidak ada sistem keamanan yang dapat menjamin
-                perlindungan mutlak. Anda juga bertanggung jawab untuk menjaga
-                kerahasiaan akses ke akun Anda.
-              </p>
             </div>
-          </div>
 
-          {/* Pasal 8 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 8 -</span>
-              Hak-Hak Anda sebagai Subjek Data
-            </h2>
-            <div className="space-y-6">
-              <p>
-                Sesuai dengan ketentuan Undang-Undang Nomor 27 Tahun 2022
-                tentang Pelindungan Data Pribadi, Anda memiliki hak-hak berikut
-                yang dapat Anda gunakan kapan saja:
-              </p>
-
-              <div className="space-y-2">
-                <h4 className="font-bold text-[#374151]">
-                  Hak Informasi (Pasal 8 UU PDP)
-                </h4>
+            {/* Pasal 12 */}
+            <div id="pasal-12" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 12 -</span>
+                Pembaruan Kebijakan Privasi
+              </h2>
+              <div className="space-y-4">
                 <p>
-                  Anda berhak mendapatkan informasi yang jelas dan transparan
-                  mengenai identitas Pengelola, tujuan pemrosesan data pribadi,
-                  periode retensi, serta hak-hak Anda.
+                  Kami berhak memperbarui atau mengubah Kebijakan Privasi ini
+                  sewaktu-waktu untuk mencerminkan perubahan pada praktik
+                  pemrosesan data, fitur layanan, atau peraturan
+                  perundang-undangan yang berlaku. Setiap perubahan yang bersifat
+                  material akan diberitahukan kepada Anda melalui surel yang
+                  terdaftar atau melalui pemberitahuan yang ditampilkan secara
+                  mencolok di Situs, sekurang-kurangnya 14 (empat belas) hari
+                  sebelum perubahan tersebut berlaku. Tanggal pembaruan terakhir
+                  akan selalu dicantumkan pada bagian bawah kebijakan ini.
+                  Penggunaan layanan Kami yang berlanjut setelah tanggal
+                  berlakunya perubahan akan dianggap sebagai penerimaan Anda
+                  terhadap Kebijakan Privasi yang telah diperbarui.
                 </p>
               </div>
+            </div>
 
-              <div className="space-y-2">
-                <h4 className="font-bold text-[#374151]">
-                  Hak Akses (Pasal 9 UU PDP)
-                </h4>
+            {/* Pasal 13 */}
+            <div id="pasal-13" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 13 -</span>
+                Penyelesaian Sengketa
+              </h2>
+              <div className="space-y-4">
                 <p>
-                  Anda berhak memperoleh salinan data pribadi yang Kami miliki
-                  tentang Anda, beserta informasi mengenai cara data tersebut
-                  diproses.
+                  Apabila Anda merasa bahwa Kami telah melanggar hak-hak Anda
+                  terkait data pribadi, Anda dapat:
                 </p>
+                <div className="space-y-2">
+                  {[
+                    "Mengajukan pengaduan secara tertulis kepada Kami melalui surel legal@splitbill.my.id. Kami akan menangani setiap pengaduan dengan serius dan merespons dalam jangka waktu paling lama 14 (empat belas) hari kerja;",
+                    "Mengajukan pengaduan kepada Komisi Informasi Publik atau lembaga pengawas pelindungan data pribadi yang berwenang berdasarkan ketentuan UU PDP apabila Anda tidak puas dengan tanggapan Kami;",
+                    "Menempuh jalur hukum yang tersedia berdasarkan peraturan perundang-undangan yang berlaku di Republik Indonesia.",
+                  ].map((item, i) => (
+                    <div key={i} className="flex gap-2 pl-4">
+                      <span className="text-[#9ca3af] shrink-0">•</span>
+                      <p>{item}</p>
+                    </div>
+                  ))}
+                </div>
               </div>
+            </div>
 
-              <div className="space-y-2">
-                <h4 className="font-bold text-[#374151]">
-                  Hak Perbaikan (Pasal 10 UU PDP)
-                </h4>
+            {/* Pasal 14 */}
+            <div id="pasal-14" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 14 -</span>
+                Informasi Kontak
+              </h2>
+              <div className="space-y-4 text-left">
                 <p>
-                  Anda berhak meminta perbaikan atas data pribadi yang tidak
-                  akurat, tidak lengkap, atau yang sudah tidak relevan.
+                  Apabila Anda memiliki pertanyaan, kekhawatiran, atau ingin
+                  menggunakan hak-hak Anda sebagaimana diuraikan dalam Kebijakan
+                  Privasi ini, silakan menghubungi Kami melalui:
                 </p>
-              </div>
-
-              <div className="space-y-2">
-                <h4 className="font-bold text-[#374151]">
-                  Hak Penghapusan (Pasal 11 UU PDP)
-                </h4>
                 <p>
-                  Anda berhak meminta penghapusan data pribadi Anda ("hak untuk
-                  dilupakan") dalam kondisi-kondisi tertentu sebagaimana diatur
-                  dalam UU PDP.
-                </p>
-              </div>
-
-              <div className="space-y-2">
-                <h4 className="font-bold text-[#374151]">
-                  Hak Pembatasan Pemrosesan (Pasal 12 UU PDP)
-                </h4>
-                <p>
-                  Anda berhak meminta pembatasan atas pemrosesan data pribadi
-                  Anda dalam kondisi tertentu, misalnya selama sengketa mengenai
-                  keakuratan data sedang diselesaikan.
-                </p>
-              </div>
-
-              <div className="space-y-2">
-                <h4 className="font-bold text-[#374151]">
-                  Hak Portabilitas Data (Pasal 13 UU PDP)
-                </h4>
-                <p>
-                  Anda berhak menerima data pribadi Anda dalam format yang
-                  terstruktur, umum digunakan, dan dapat dibaca oleh mesin,
-                  serta berhak untuk mentransfer data tersebut kepada pengendali
-                  data lain.
-                </p>
-              </div>
-
-              <div className="space-y-2">
-                <h4 className="font-bold text-[#374151]">
-                  Hak Penarikan Persetujuan (Pasal 20 UU PDP)
-                </h4>
-                <p>
-                  Anda berhak menarik kembali persetujuan yang telah Anda
-                  berikan kapan saja, tanpa mengurangi keabsahan pemrosesan yang
-                  telah dilakukan berdasarkan persetujuan sebelum penarikan.
-                </p>
-              </div>
-
-              <div className="space-y-2">
-                <h4 className="font-bold text-[#374151]">
-                  Hak untuk Mengajukan Keberatan (Pasal 14 UU PDP)
-                </h4>
-                <p>
-                  Anda berhak mengajukan keberatan atas pemrosesan data pribadi
-                  Anda, termasuk pemrosesan untuk kepentingan pemasaran langsung
-                  atau pengambilan keputusan otomatis yang berdampak signifikan
-                  terhadap Anda.
-                </p>
-              </div>
-
-              <div className="space-y-3">
-                <h4 className="font-bold text-[#374151]">
-                  Cara Menggunakan Hak Anda
-                </h4>
-                <p>
-                  Untuk menggunakan hak-hak tersebut di atas, Anda dapat
-                  mengajukan permintaan tertulis kepada Kami melalui surel ke{" "}
+                  <strong className="text-[#111827]">Pengelola Data:</strong>{" "}
+                  Split Bill Online
+                  <br />
+                  <strong className="text-[#111827]">Situs Web:</strong>{" "}
+                  https://splitbill.my.id
+                  <br />
+                  <strong className="text-[#111827]">Surel:</strong>{" "}
                   <a
                     href="mailto:legal@splitbill.my.id"
                     className="text-primary font-bold hover:underline"
                   >
                     legal@splitbill.my.id
                   </a>
-                  . Kami akan merespons permintaan Anda dalam jangka waktu
-                  paling lama 14 (empat belas) hari kerja sejak permintaan
-                  diterima. Untuk keperluan penghapusan akun, Kami akan
-                  menyelesaikan proses tersebut dalam jangka waktu paling lama
-                  30 (tiga puluh) hari kalender. Kami dapat meminta verifikasi
-                  identitas Anda sebelum memproses permintaan guna memastikan
-                  keamanan data Anda.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* Pasal 9 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 9 -</span>
-              Penggunaan Kuki (Cookies)
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Situs Kami menggunakan kuki dan teknologi pelacakan serupa untuk
-                meningkatkan fungsionalitas dan pengalaman pengguna. Jenis-jenis
-                kuki yang Kami gunakan adalah sebagai berikut:
-              </p>
-              <div className="space-y-3 pl-4">
-                <p>
-                  <strong className="text-[#111827]">Kuki Esensial:</strong>{" "}
-                  Kuki yang mutlak diperlukan untuk fungsi dasar Situs, seperti
-                  pemeliharaan sesi autentikasi. Kuki ini tidak dapat
-                  dinonaktifkan.
                 </p>
                 <p>
-                  <strong className="text-[#111827]">Kuki Fungsional:</strong>{" "}
-                  Kuki yang digunakan untuk menyimpan preferensi pengguna,
-                  seperti pilihan bahasa dan pengaturan tampilan.
+                  Kami berkomitmen untuk merespons setiap pertanyaan atau
+                  permintaan Anda dalam jangka waktu yang wajar.
                 </p>
-                <p>
-                  <strong className="text-[#111827]">Kuki Analitik:</strong>{" "}
-                  Kuki yang digunakan untuk mengumpulkan data anonim mengenai
-                  penggunaan Situs guna membantu Kami memahami pola penggunaan
-                  dan meningkatkan layanan.
-                </p>
-              </div>
-              <p>
-                Anda dapat mengatur preferensi kuki melalui pengaturan peramban
-                Anda. Namun, menonaktifkan kuki tertentu dapat memengaruhi
-                fungsi dan pengalaman penggunaan Situs.
-              </p>
-            </div>
-          </div>
-
-          {/* Pasal 10 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 10 -</span>
-              Transfer Data Lintas Batas Negara
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Dalam rangka penggunaan layanan Google Cloud Platform dan Google
-                Generative AI, data pribadi Anda dapat ditransfer dan diproses
-                di server yang berlokasi di luar wilayah Republik Indonesia.
-                Transfer data tersebut dilakukan sesuai dengan ketentuan Pasal
-                56 UU PDP dan peraturan pelaksanaannya. Kami memastikan bahwa
-                setiap transfer data lintas batas negara dilakukan dengan
-                perlindungan yang memadai, termasuk melalui perjanjian yang
-                mengharuskan penerima data untuk memberikan tingkat perlindungan
-                yang setara dengan yang ditetapkan dalam UU PDP. Anda menyetujui
-                transfer data tersebut dengan menggunakan layanan Kami.
-              </p>
-            </div>
-          </div>
-
-          {/* Pasal 11 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 11 -</span>
-              Tautan dan Layanan Pihak Ketiga
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Situs Kami dapat memuat tautan menuju situs web atau layanan
-                pihak ketiga. Kebijakan Privasi ini tidak berlaku terhadap situs
-                web atau layanan pihak ketiga tersebut. Kami tidak bertanggung
-                jawab atas praktik privasi atau konten dari situs web atau
-                layanan pihak ketiga tersebut. Kami mendorong Anda untuk membaca
-                dan memahami kebijakan privasi dari setiap situs web atau
-                layanan pihak ketiga yang Anda kunjungi atau gunakan.
-              </p>
-            </div>
-          </div>
-
-          {/* Pasal 12 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 12 -</span>
-              Pembaruan Kebijakan Privasi
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Kami berhak memperbarui atau mengubah Kebijakan Privasi ini
-                sewaktu-waktu untuk mencerminkan perubahan pada praktik
-                pemrosesan data, fitur layanan, atau peraturan
-                perundang-undangan yang berlaku. Setiap perubahan yang bersifat
-                material akan diberitahukan kepada Anda melalui surel yang
-                terdaftar atau melalui pemberitahuan yang ditampilkan secara
-                mencolok di Situs, sekurang-kurangnya 14 (empat belas) hari
-                sebelum perubahan tersebut berlaku. Tanggal pembaruan terakhir
-                akan selalu dicantumkan pada bagian bawah kebijakan ini.
-                Penggunaan layanan Kami yang berlanjut setelah tanggal
-                berlakunya perubahan akan dianggap sebagai penerimaan Anda
-                terhadap Kebijakan Privasi yang telah diperbarui.
-              </p>
-            </div>
-          </div>
-
-          {/* Pasal 13 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 13 -</span>
-              Penyelesaian Sengketa
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Apabila Anda merasa bahwa Kami telah melanggar hak-hak Anda
-                terkait data pribadi, Anda dapat:
-              </p>
-              <div className="space-y-2">
-                {[
-                  "Mengajukan pengaduan secara tertulis kepada Kami melalui surel legal@splitbill.my.id. Kami akan menangani setiap pengaduan dengan serius dan merespons dalam jangka waktu paling lama 14 (empat belas) hari kerja;",
-                  "Mengajukan pengaduan kepada Komisi Informasi Publik atau lembaga pengawas pelindungan data pribadi yang berwenang berdasarkan ketentuan UU PDP apabila Anda tidak puas dengan tanggapan Kami;",
-                  "Menempuh jalur hukum yang tersedia berdasarkan peraturan perundang-undangan yang berlaku di Republik Indonesia.",
-                ].map((item, i) => (
-                  <div key={i} className="flex gap-2 pl-4">
-                    <span className="text-[#9ca3af] shrink-0">•</span>
-                    <p>{item}</p>
-                  </div>
-                ))}
+                <div className="pt-4 space-y-1">
+                  <p className="text-sm font-bold text-[#111827]">
+                    Kebijakan Privasi ini berlaku sejak 16 Mei 2026
+                  </p>
+                  <p className="text-xs">
+                    © 2026 Split Bill Online - splitbill.my.id
+                  </p>
+                  <p className="text-[10px] italic">
+                    Dokumen ini disusun sesuai dengan UU No. 27 Tahun 2022 tentang
+                    Pelindungan Data Pribadi
+                  </p>
+                </div>
               </div>
             </div>
-          </div>
 
-          {/* Pasal 14 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 14 -</span>
-              Informasi Kontak
-            </h2>
-            <div className="space-y-4 text-left">
-              <p>
-                Apabila Anda memiliki pertanyaan, kekhawatiran, atau ingin
-                menggunakan hak-hak Anda sebagaimana diuraikan dalam Kebijakan
-                Privasi ini, silakan menghubungi Kami melalui:
+            {/* Bottom Navigation */}
+            <div className="pt-10 border-t border-border flex flex-col items-start gap-12 text-left cursor-pointer">
+              <Link href="/">
+                <button className="flex items-center gap-2 text-primary font-bold text-sm hover:opacity-70 transition-opacity">
+                  <ArrowLeft className="w-4 h-4" />
+                  Kembali ke Beranda
+                </button>
+              </Link>
+              <p className="text-xs text-muted-foreground">
+                Dengan menggunakan SplitBill Online, Anda dianggap telah membaca
+                dan menyetujui Kebijakan Privasi ini. Kami menyarankan Anda untuk
+                meninjau halaman ini secara berkala.
               </p>
-              <p>
-                <strong className="text-[#111827]">Pengelola Data:</strong>{" "}
-                Split Bill Online
-                <br />
-                <strong className="text-[#111827]">Situs Web:</strong>{" "}
-                https://splitbill.my.id
-                <br />
-                <strong className="text-[#111827]">Surel:</strong>{" "}
-                <a
-                  href="mailto:legal@splitbill.my.id"
-                  className="text-primary font-bold hover:underline"
-                >
-                  legal@splitbill.my.id
-                </a>
-              </p>
-              <p>
-                Kami berkomitmen untuk merespons setiap pertanyaan atau
-                permintaan Anda dalam jangka waktu yang wajar.
-              </p>
-              <div className="pt-4 space-y-1">
-                <p className="text-sm font-bold text-[#111827]">
-                  Kebijakan Privasi ini berlaku sejak 16 Mei 2026
-                </p>
-                <p className="text-xs">
-                  © 2026 Split Bill Online - splitbill.my.id
-                </p>
-                <p className="text-[10px] italic">
-                  Dokumen ini disusun sesuai dengan UU No. 27 Tahun 2022 tentang
-                  Pelindungan Data Pribadi
-                </p>
-              </div>
             </div>
-          </div>
-
-          {/* Bottom Navigation */}
-          <div className="pt-10 border-t border-border flex flex-col items-start gap-12 text-left cursor-pointer">
-            <Link href="/">
-              <button className="flex items-center gap-2 text-primary font-bold text-sm hover:opacity-70 transition-opacity">
-                <ArrowLeft className="w-4 h-4" />
-                Kembali ke Beranda
-              </button>
-            </Link>
-            <p className="text-xs text-muted-foreground">
-              Dengan menggunakan SplitBill Online, Anda dianggap telah membaca
-              dan menyetujui Kebijakan Privasi ini. Kami menyarankan Anda untuk
-              meninjau halaman ini secara berkala.
-            </p>
-          </div>
-        </motion.div>
+          </motion.div>
+        </div>
       </main>
 
+      <HomepageFooter />
       <Footer />
     </div>
   );

--- a/src/app/split-bill/SplitBillClientPage.tsx
+++ b/src/app/split-bill/SplitBillClientPage.tsx
@@ -69,6 +69,7 @@ const SplitBillContent = () => {
     clearDraftAfterFinalize,
     setPeople,
     setSource,
+    clearSource,
     sourceBucketId,
     sourceReceiptId,
   } = useSplitBillStore();
@@ -92,6 +93,10 @@ const SplitBillContent = () => {
           console.error("Failed to parse participants from searchParams", e);
         }
       }
+    } else {
+      // Clear any stale sourceBucketId from a previous split-later session
+      // stored in localStorage, so back navigation goes to "/" instead of the old bucket
+      clearSource();
     }
   }, [searchParams]);
 

--- a/src/app/split-later/[bucketId]/BucketDetailClientPage.tsx
+++ b/src/app/split-later/[bucketId]/BucketDetailClientPage.tsx
@@ -166,7 +166,7 @@ export default function BucketDetailClientPage({
           <Header
             title={`${bucket.emoji} ${bucket.title}`}
             showBackButton
-            onBack={() => router.push("/split-later")}
+            onBack={() => router.back()}
             transparent
             rightContent={
               <div className="flex items-center gap-1">

--- a/src/app/terms/TermsClientPage.tsx
+++ b/src/app/terms/TermsClientPage.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import React from "react";
-import { Header } from "@/components/layout/Header";
+import { HomepageNavbar } from "@/components/homepage/HomepageNavbar";
 import { Footer } from "@/components/layout/Footer";
+import { HomepageFooter } from "@/components/homepage/HomepageFooter";
+import { cn } from "@/lib/utils";
 import {
   ArrowLeft,
   Scale,
@@ -15,596 +17,663 @@ import {
 import { motion } from "framer-motion";
 import Link from "next/link";
 
+const sections = [
+  { id: "ringkasan", label: "Ringkasan Dokumen" },
+  { id: "pasal-1", label: "Pasal 1: Penerimaan & Kekuatan Mengikat" },
+  { id: "pasal-2", label: "Pasal 2: Identitas Pengelola" },
+  { id: "pasal-3", label: "Pasal 3: Definisi" },
+  { id: "pasal-4", label: "Pasal 4: Ruang Lingkup Layanan" },
+  { id: "pasal-5", label: "Pasal 5: Sifat & Batasan Layanan" },
+  { id: "pasal-6", label: "Pasal 6: Pendaftaran & Keamanan Akun" },
+  { id: "pasal-7", label: "Pasal 7: Ketentuan Penggunaan" },
+  { id: "pasal-8", label: "Pasal 8: Larangan Penggunaan" },
+  { id: "pasal-9", label: "Pasal 9: Hak Kekayaan Intelektual" },
+  { id: "pasal-10", label: "Pasal 10: Perlindungan Data Pribadi" },
+  { id: "pasal-11", label: "Pasal 11: Layanan Pihak Ketiga" },
+  { id: "pasal-12", label: "Pasal 12: Penangguhan & Penghentian Akun" },
+  { id: "pasal-13", label: "Pasal 13: Pembaruan Syarat & Ketentuan" },
+  { id: "pasal-14", label: "Pasal 14: Ganti Rugi (Indemnifikasi)" },
+  { id: "pasal-15", label: "Pasal 15: Hukum & Penyelesaian Sengketa" },
+  { id: "pasal-16", label: "Pasal 16: Ketentuan Lain-Lain" },
+  { id: "pasal-17", label: "Pasal 17: Informasi Kontak" },
+];
+
 export default function TermsClientPage() {
   const lastUpdated = "19 Februari 2026";
+  const [activeSection, setActiveSection] = React.useState("");
+
+  React.useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveSection(entry.target.id);
+          }
+        });
+      },
+      { rootMargin: "-10% 0px -85% 0px" }
+    );
+
+    sections.forEach((s) => {
+      const el = document.getElementById(s.id);
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, []);
 
   return (
-    <div className="min-h-screen bg-white flex flex-col items-center">
-      <Header sticky showBackButton title="Syarat & Ketentuan" />
+    <div className="min-h-screen bg-slate-50/50 flex flex-col items-center pt-16 lg:pt-18">
+      <HomepageNavbar />
 
       {/* Main Content Area */}
-      <main className="w-full max-w-[600px] mx-auto px-6 py-12">
-        <motion.div
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-          className="space-y-12 text-[#4b5563] leading-relaxed text-justify"
-        >
-          {/* Header Section */}
-          <div className="space-y-4 mb-10 flex flex-col items-center text-center">
-            <h1 className="text-4xl font-bold text-[#111827] tracking-tight">
-              Syarat & Ketentuan Layanan
-            </h1>
-            <div className="text-md text-[#4b5563] space-y-1">
-              <p className="font-bold">Split Bill Online</p>
-              <p>https://splitbill.my.id</p>
-              <p className="text-sm italic">Berlaku sejak: 16 Mei 2026</p>
-            </div>
-          </div>
-
-          <div className="border-b border-border w-full" />
-
-          {/* Ringkasan Dokumen */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151]">
-              Ringkasan Dokumen
-            </h2>
-            <p>
-              Syarat dan Ketentuan ini merupakan perjanjian elektronik yang
-              mengikat secara hukum antara Anda selaku pengguna dan Split Bill
-              Online selaku pengelola platform. Dokumen ini disusun sesuai
-              dengan UU No. 11 Tahun 2008 tentang ITE dan perubahannya, UU No.
-              27 Tahun 2022 tentang Pelindungan Data Pribadi, serta peraturan
-              perundang-undangan Indonesia yang berlaku.
-            </p>
-          </div>
-
-          {/* Pasal 1 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 1 -</span>
-              Penerimaan dan Kekuatan Mengikat
-            </h2>
-            <div className="space-y-4">
-              <div className="flex gap-2">
-                <span className="text-[#9ca3af] font-medium shrink-0">
-                  1.1.
-                </span>
-                <p>
-                  Dokumen ini merupakan Perjanjian Elektronik yang sah dan
-                  mengikat sebagaimana diatur dalam Pasal 18 dan Pasal 20 UU
-                  ITE, UU No. 1 Tahun 2024, serta PP PSTE.
-                </p>
-              </div>
-              <div className="flex gap-2">
-                <span className="text-[#9ca3af] font-medium shrink-0">
-                  1.2.
-                </span>
-                <p>
-                  Dengan mengakses, mendaftarkan akun, atau menggunakan layanan
-                  Split Bill Online dengan cara apa pun, Anda menyatakan secara
-                  tegas bahwa Anda telah membaca, memahami, dan menyetujui
-                  seluruh ketentuan dalam dokumen ini.
-                </p>
-              </div>
-              <div className="flex gap-2">
-                <span className="text-[#9ca3af] font-medium shrink-0">
-                  1.3.
-                </span>
-                <p>
-                  Apabila Anda tidak menyetujui sebagian atau seluruh ketentuan
-                  ini, Anda dilarang mengakses atau menggunakan layanan Kami.
-                </p>
-              </div>
-              <div className="flex gap-2">
-                <span className="text-[#9ca3af] font-medium shrink-0">
-                  1.4.
-                </span>
-                <p>
-                  Anda menyatakan bahwa Anda telah berusia minimal 18 tahun atau
-                  berada di bawah pengawasan orang tua/wali yang sah, serta
-                  memiliki kapasitas hukum untuk terikat dalam perjanjian ini.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* Pasal 2 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 2 -</span>
-              Identitas Pengelola
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Split Bill Online (selanjutnya disebut "Pengelola", "Kami", atau
-                "Milik Kami") adalah platform layanan pembagian tagihan dan
-                manajemen keuangan kolaboratif daring yang dapat diakses melalui{" "}
-                <Link
-                  href="/"
-                  className="text-primary hover:underline font-medium"
+      <main className="w-full max-w-[600px] lg:max-w-7xl mx-auto px-4 sm:px-6 py-4 sm:py-12 flex-1">
+        <div className="flex flex-col lg:flex-row gap-10 items-start">
+          {/* Sticky Sidebar on Desktop */}
+          <aside className="hidden lg:block w-72 shrink-0 sticky top-24 max-h-[calc(100vh-120px)] overflow-y-auto pr-4 border-r border-slate-100">
+            <h4 className="text-xs font-bold uppercase tracking-wider text-slate-400 mb-4 px-2">Daftar Isi</h4>
+            <nav className="space-y-1">
+              {sections.map((section) => (
+                <a
+                  key={section.id}
+                  href={`#${section.id}`}
+                  className={cn(
+                    "block py-2 px-3 text-xs font-semibold rounded-[2px] transition-all border-l-2 text-left",
+                    activeSection === section.id
+                      ? "text-primary border-primary bg-primary/5 pl-4 font-bold"
+                      : "text-slate-500 border-transparent hover:text-primary hover:bg-slate-100/50 hover:border-slate-300"
+                  )}
                 >
+                  {section.label}
+                </a>
+              ))}
+            </nav>
+          </aside>
+
+          {/* Content */}
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+            className="flex-1 space-y-12 text-[#4b5563] leading-relaxed text-justify max-w-none bg-white px-6 py-12 sm:p-14 rounded-lg border border-slate-100"
+          >
+            {/* Header Section */}
+            <div className="space-y-4 mb-10 flex flex-col items-center text-center">
+              <h1 className="text-4xl font-bold text-[#111827] tracking-tight">
+                Syarat & Ketentuan Layanan
+              </h1>
+              <div className="text-md text-[#4b5563] space-y-1">
+                <p className="font-bold">Split Bill Online</p>
+                <p>https://splitbill.my.id</p>
+                <p className="text-sm italic">Berlaku sejak: 16 Mei 2026</p>
+              </div>
+            </div>
+
+            <div className="border-b border-border w-full" />
+
+            {/* Ringkasan Dokumen */}
+            <div id="ringkasan" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151]">
+                Ringkasan Dokumen
+              </h2>
+              <p>
+                Syarat dan Ketentuan ini merupakan perjanjian elektronik yang
+                mengikat secara hukum antara Anda selaku pengguna dan Split Bill
+                Online selaku pengelola platform. Dokumen ini disusun sesuai
+                dengan UU No. 11 Tahun 2008 tentang ITE dan perubahannya, UU No.
+                27 Tahun 2022 tentang Pelindungan Data Pribadi, serta peraturan
+                perundang-undangan Indonesia yang berlaku.
+              </p>
+            </div>
+
+            {/* Pasal 1 */}
+            <div id="pasal-1" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 1 -</span>
+                Penerimaan dan Kekuatan Mengikat
+              </h2>
+              <div className="space-y-4">
+                <div className="flex gap-2">
+                  <span className="text-[#9ca3af] font-medium shrink-0">
+                    1.1.
+                  </span>
+                  <p>
+                    Dokumen ini merupakan Perjanjian Elektronik yang sah dan
+                    mengikat sebagaimana diatur dalam Pasal 18 dan Pasal 20 UU
+                    ITE, UU No. 1 Tahun 2024, serta PP PSTE.
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  <span className="text-[#9ca3af] font-medium shrink-0">
+                    1.2.
+                  </span>
+                  <p>
+                    Dengan mengakses, mendaftarkan akun, atau menggunakan layanan
+                    Split Bill Online dengan cara apa pun, Anda menyatakan secara
+                    tegas bahwa Anda telah membaca, memahami, dan menyetujui
+                    seluruh ketentuan dalam dokumen ini.
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  <span className="text-[#9ca3af] font-medium shrink-0">
+                    1.3.
+                  </span>
+                  <p>
+                    Apabila Anda tidak menyetujui sebagian atau seluruh ketentuan
+                    ini, Anda dilarang mengakses atau menggunakan layanan Kami.
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  <span className="text-[#9ca3af] font-medium shrink-0">
+                    1.4.
+                  </span>
+                  <p>
+                    Anda menyatakan bahwa Anda telah berusia minimal 18 tahun atau
+                    berada di bawah pengawasan orang tua/wali yang sah, serta
+                    memiliki kapasitas hukum untuk terikat dalam perjanjian ini.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Pasal 2 */}
+            <div id="pasal-2" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 2 -</span>
+                Identitas Pengelola
+              </h2>
+              <div className="space-y-4">
+                <p>
+                  Split Bill Online (selanjutnya disebut "Pengelola", "Kami", atau
+                  "Milik Kami") adalah platform layanan pembagian tagihan dan
+                  manajemen keuangan kolaboratif daring yang dapat diakses melalui{" "}
+                  <Link
+                    href="/"
+                    className="text-primary hover:underline font-medium"
+                  >
+                    https://splitbill.my.id
+                  </Link>
+                  . Pengelola dapat dihubungi melalui surel resmi:{" "}
+                  <a
+                    href="mailto:legal@splitbill.my.id"
+                    className="text-primary font-bold hover:underline"
+                  >
+                    legal@splitbill.my.id
+                  </a>
+                  .
+                </p>
+              </div>
+            </div>
+
+            {/* Pasal 3 */}
+            <div id="pasal-3" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 3 -</span>
+                Definisi
+              </h2>
+              <div className="space-y-4">
+                <p>
+                  Dalam Syarat dan Ketentuan ini, istilah-istilah berikut memiliki
+                  makna sebagaimana didefinisikan:
+                </p>
+                <div className="space-y-3">
+                  {[
+                    {
+                      k: "Platform",
+                      v: "Situs web https://splitbill.my.id beserta seluruh fitur dan layanan di dalamnya.",
+                    },
+                    {
+                      k: "Pengguna",
+                      v: "Individu yang mengakses Platform, baik dengan atau tanpa akun.",
+                    },
+                    {
+                      k: "Akun",
+                      v: "Akun yang didaftarkan melalui Google OAuth 2.0 untuk akses fitur tersimpan.",
+                    },
+                    {
+                      k: "Konten Pengguna",
+                      v: "Data, teks, atau gambar yang diunggah atau dibuat oleh Anda di Platform.",
+                    },
+                    {
+                      k: "Layanan",
+                      v: "Seluruh fitur dan fungsi yang disediakan oleh Pengelola melalui Platform.",
+                    },
+                    {
+                      k: "Data Pribadi",
+                      v: "Data tentang orang perseorangan sebagaimana didefinisikan dalam UU PDP.",
+                    },
+                  ].map((item, i) => (
+                    <div key={i} className="flex gap-2">
+                      <span className="text-[#9ca3af] font-medium shrink-0">
+                        {String.fromCharCode(97 + i)}.
+                      </span>
+                      <p>
+                        <strong className="text-[#111827]">"{item.k}"</strong>{" "}
+                        berarti {item.v}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {/* Pasal 4 */}
+            <div id="pasal-4" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 4 -</span>
+                Ruang Lingkup Layanan
+              </h2>
+              <div className="space-y-6">
+                <div className="space-y-3">
+                  <h3 className="font-bold text-[#374151]">
+                    4.1 Split Bill dan Pemindaian Struk
+                  </h3>
+                  <p>
+                    Fitur pembagian tagihan yang mengintegrasikan teknologi AI OCR
+                    (Optical Character Recognition) untuk mengekstraksi data
+                    nominal secara otomatis dari gambar struk fisik maupun
+                    digital.
+                  </p>
+                </div>
+                <div className="space-y-3">
+                  <h3 className="font-bold text-[#374151]">
+                    4.2 Invoice Digital
+                  </h3>
+                  <p>
+                    Fitur pembuatan tagihan digital sebagai sarana pencatatan dan
+                    dokumentasi pengeluaran bersama.
+                  </p>
+                </div>
+                <div className="space-y-3">
+                  <h3 className="font-bold text-[#374151]">
+                    4.3 Tujuan Bersama (Shared Goals)
+                  </h3>
+                  <p>
+                    Fitur pelacakan target keuangan bersama untuk memantau progres
+                    pencapaian tujuan kolektif.
+                  </p>
+                </div>
+                <div className="space-y-3">
+                  <h3 className="font-bold text-[#374151]">
+                    4.4 Pengumpulan Iuran (Collect Money)
+                  </h3>
+                  <p>
+                    Fitur manajemen iuran kelompok sebagai alat pembukuan digital
+                    untuk kebutuhan patungan atau kas bersama.
+                  </p>
+                </div>
+                <div className="space-y-3">
+                  <h3 className="font-bold text-[#374151]">
+                    4.5 Dompet Digital (Wallet)
+                  </h3>
+                  <p>
+                    Fitur pencatatan saldo pribadi yang berfungsi semata-mata
+                    sebagai alat pembukuan digital dan bukan dompet elektronik
+                    berizin Bank Indonesia.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Pasal 5 */}
+            <div id="pasal-5" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 5 -</span>
+                Sifat dan Batasan Layanan
+              </h2>
+              <div className="space-y-6">
+                <div className="space-y-3">
+                  <h3 className="font-bold text-[#374151]">
+                    5.1 Bukan Lembaga Keuangan
+                  </h3>
+                  <p>
+                    Split Bill Online secara tegas bukan merupakan bank, lembaga
+                    keuangan, atau penyelenggara jasa pembayaran. Kami tidak
+                    menyimpan atau mengelola dana Pengguna secara aktual.
+                  </p>
+                </div>
+                <div className="space-y-3">
+                  <h3 className="font-bold text-[#374151]">
+                    5.2 Akurasi Kecerdasan Buatan
+                  </h3>
+                  <p>
+                    Fitur AI dikembangkan oleh pihak ketiga. Kami tidak menjamin
+                    akurasi 100% dan Pengguna wajib memverifikasi kembali seluruh
+                    data sebelum finalisasi. Pengelola tidak bertanggung jawab
+                    atas kesalahan ekstraksi sistem AI.
+                  </p>
+                </div>
+                <div className="space-y-3">
+                  <h3 className="font-bold text-[#374151]">
+                    5.3 Tanggung Jawab Pembayaran
+                  </h3>
+                  <p>
+                    Transaksi keuangan yang dicatat merupakan tanggung jawab
+                    pribadi antar Pengguna. Pengelola tidak bertanggung jawab atas
+                    gagal bayar atau sengketa antar Pengguna.
+                  </p>
+                </div>
+                <div className="space-y-3">
+                  <h3 className="font-bold text-[#374151]">
+                    5.4 Ketersediaan Layanan
+                  </h3>
+                  <p>
+                    Kami berupaya menyediakan layanan kontinu namun tidak menjamin
+                    kebebasan mutlak dari gangguan teknis atau pemeliharaan sistem
+                    sewaktu-waktu.
+                  </p>
+                </div>
+                <div className="space-y-3">
+                  <h3 className="font-bold text-[#374151]">
+                    5.5 Batasan Tanggung Jawab
+                  </h3>
+                  <p>
+                    Pengelola tidak bertanggung jawab atas kerugian tidak
+                    langsung, insidental, atau konsekuensial yang timbul dari
+                    penggunaan Platform.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Pasal 6 */}
+            <div id="pasal-6" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 6 -</span>
+                Pendaftaran dan Keamanan Akun
+              </h2>
+              <div className="space-y-4">
+                <div className="flex gap-2">
+                  <span className="text-[#9ca3af] font-medium shrink-0">
+                    6.1.
+                  </span>
+                  <p>
+                    Fitur dasar dapat digunakan tanpa akun, di mana data disimpan
+                    secara lokal di perangkat Anda (local storage browser).
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  <span className="text-[#9ca3af] font-medium shrink-0">
+                    6.2.
+                  </span>
+                  <p>
+                    Sinkronisasi data lintas perangkat memerlukan pendaftaran akun
+                    melalui Google OAuth 2.0.
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  <span className="text-[#9ca3af] font-medium shrink-0">
+                    6.3.
+                  </span>
+                  <p>
+                    Pengguna bertanggung jawab penuh atas keamanan akses akun dan
+                    wajib melapor jika terjadi indikasi akses tidak sah.
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  <span className="text-[#9ca3af] font-medium shrink-0">
+                    6.4.
+                  </span>
+                  <p>
+                    Satu Pengguna hanya diperbolehkan memiliki satu akun aktif.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Pasal 7 */}
+            <div id="pasal-7" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 7 -</span>
+                Ketentuan Penggunaan yang Diizinkan
+              </h2>
+              <div className="space-y-4">
+                <p>Pengguna diizinkan menggunakan Platform untuk:</p>
+                <div className="space-y-2">
+                  {[
+                    "Membagi tagihan sosial antar individu yang sah.",
+                    "Mengelola catatan keuangan kolaboratif non-komersial.",
+                    "Menggunakan AI OCR untuk membantu pencatatan nominal.",
+                    "Mengakses dan mengunduh riwayat transaksi pribadi.",
+                  ].map((item, i) => (
+                    <div key={i} className="flex gap-2 pl-4">
+                      <span className="text-[#9ca3af] shrink-0">•</span>
+                      <p>{item}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {/* Pasal 8 */}
+            <div id="pasal-8" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 8 -</span>
+                Larangan Penggunaan
+              </h2>
+              <div className="space-y-6">
+                <div className="space-y-3">
+                  <h3 className="font-bold text-[#374151]">
+                    8.1 Kegiatan Ilegal
+                  </h3>
+                  <p>
+                    Larangan keras atas pencucian uang, pendanaan terorisme, atau
+                    penipuan dalam bentuk apa pun.
+                  </p>
+                </div>
+                <div className="space-y-3">
+                  <h3 className="font-bold text-[#374151]">
+                    8.2 Manipulasi Data
+                  </h3>
+                  <p>
+                    Dilarang mengunggah struk palsu atau memanipulasi data untuk
+                    menyesatkan Pengguna lain.
+                  </p>
+                </div>
+                <div className="space-y-3">
+                  <h3 className="font-bold text-[#374151]">
+                    8.3 Gangguan Sistem
+                  </h3>
+                  <p>
+                    Dilarang melakukan rekayasa balik (reverse engineering) atau
+                    meretas infrastruktur teknis Platform.
+                  </p>
+                </div>
+                <div className="space-y-3">
+                  <h3 className="font-bold text-[#374151]">
+                    8.4 Konten Terlarang
+                  </h3>
+                  <p>
+                    Dilarang mengunggah konten SARA, pornografi, kekerasan, atau
+                    ujaran kebencian.
+                  </p>
+                </div>
+                <p className="text-sm font-medium text-destructive/80 italic">
+                  Pelanggaran berat dapat mengakibatkan penghapusan akun permanen
+                  dan tindakan hukum sesuai regulasi RI.
+                </p>
+              </div>
+            </div>
+
+            {/* Pasal 9 */}
+            <div id="pasal-9" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 9 -</span>
+                Hak Kekayaan Intelektual
+              </h2>
+              <div className="space-y-4">
+                <p>
+                  Seluruh desain, kode program, logo, dan merek dagang merupakan
+                  milik eksklusif{" "}
+                  <strong className="text-[#111827]">Split Bill Online</strong>{" "}
+                  dan dilindungi UU Hak Cipta & UU Merek Republik Indonesia.
+                  Pengguna diberikan lisensi terbatas hanya untuk penggunaan
+                  pribadi non-komersial.
+                </p>
+              </div>
+            </div>
+
+            {/* Pasal 10 */}
+            <div id="pasal-10" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 10 -</span>
+                Perlindungan Data Pribadi
+              </h2>
+              <div className="space-y-4">
+                <p>
+                  Pemrosesan data dilaksanakan sesuai UU PDP dan Kebijakan Privasi
+                  Kami. Kebijakan Privasi merupakan bagian tidak terpisahkan dari
+                  Syarat & Ketentuan ini.
+                </p>
+              </div>
+            </div>
+
+            {/* Pasal 11 */}
+            <div id="pasal-11" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 11 -</span>
+                Layanan Pihak Ketiga
+              </h2>
+              <div className="space-y-4">
+                <p>
+                  Penggunaan integrasi Google OAuth, Cloud, dan AI tunduk pada
+                  ketentuan masing-masing penyedia. Kami tidak bertanggung jawab
+                  atas konten atau praktik layanan pihak ketiga tersebut.
+                </p>
+              </div>
+            </div>
+
+            {/* Pasal 12 */}
+            <div id="pasal-12" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 12 -</span>
+                Penangguhan dan Penghentian Akun
+              </h2>
+              <div className="space-y-4">
+                <p>
+                  Kami berhak menghapus akun yang melanggar ketentuan. Pengguna
+                  juga dapat meminta penghapusan akun kapan saja melalui surel
+                  legal, dengan proses penyelesaian maksimal 30 hari kalender.
+                </p>
+              </div>
+            </div>
+
+            {/* Pasal 13 */}
+            <div id="pasal-13" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 13 -</span>
+                Pembaruan Syarat dan Ketentuan
+              </h2>
+              <div className="space-y-4">
+                <p>
+                  Pembaruan dilakukan sewaktu-waktu. Perubahan material akan
+                  diberitahukan 14 hari sebelumnya. Penggunaan berlanjut dianggap
+                  sebagai persetujuan atas versi terbaru.
+                </p>
+              </div>
+            </div>
+
+            {/* Pasal 14 */}
+            <div id="pasal-14" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 14 -</span>
+                Ganti Rugi (Indemnifikasi)
+              </h2>
+              <div className="space-y-4">
+                <p>
+                  Pengguna setuju untuk membebaskan Pengelola dari segala klaim
+                  atau tuntutan hukum yang timbul akibat penyalahgunaan Platform
+                  atau pelanggaran hak pihak ketiga oleh Pengguna.
+                </p>
+              </div>
+            </div>
+
+            {/* Pasal 15 */}
+            <div id="pasal-15" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 15 -</span>
+                Hukum dan Penyelesaian Sengketa
+              </h2>
+              <div className="space-y-4">
+                <p>
+                  Tunduk pada hukum Republik Indonesia. Sengketa diselesaikan
+                  secara musyawarah (30 hari), mediasi, dan terakhir melalui
+                  litigasi di Pengadilan Negeri Jakarta Pusat.
+                </p>
+              </div>
+            </div>
+
+            {/* Pasal 16 */}
+            <div id="pasal-16" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 16 -</span>
+                Ketentuan Lain-Lain
+              </h2>
+              <div className="space-y-4">
+                <p>
+                  Mencakup ketentuan mengenai keterpisahan (severability), tidak
+                  adanya pengesampingan hak, keseluruhan perjanjian, pengalihan
+                  hak, dan keadaan kahar (force majeure).
+                </p>
+              </div>
+            </div>
+
+            {/* Pasal 17 */}
+            <div id="pasal-17" className="space-y-4 scroll-mt-28">
+              <h2 className="text-lg font-bold text-[#374151] flex gap-2">
+                <span className="text-[#9ca3af] font-medium">Pasal 17 -</span>
+                Informasi Kontak
+              </h2>
+              <div className="space-y-4 text-left">
+                <p>
+                  <strong className="text-[#111827]">Pengelola:</strong> Split
+                  Bill Online
+                  <br />
+                  <strong className="text-[#111827]">Situs Web:</strong>{" "}
                   https://splitbill.my.id
-                </Link>
-                . Pengelola dapat dihubungi melalui surel resmi:{" "}
-                <a
-                  href="mailto:legal@splitbill.my.id"
-                  className="text-primary font-bold hover:underline"
-                >
-                  legal@splitbill.my.id
-                </a>
-                .
+                  <br />
+                  <strong className="text-[#111827]">Surel:</strong>{" "}
+                  <a
+                    href="mailto:legal@splitbill.my.id"
+                    className="text-primary font-bold hover:underline"
+                  >
+                    legal@splitbill.my.id
+                  </a>
+                </p>
+                <div className="pt-4 space-y-1">
+                  <p className="text-sm font-bold text-[#111827]">
+                    Syarat dan Ketentuan ini berlaku sejak 16 Mei 2026
+                  </p>
+                  <p className="text-xs">
+                    © 2026 Split Bill Online - splitbill.my.id
+                  </p>
+                  <p className="text-[10px] italic">
+                    Dokumen ini disusun sesuai dengan UU ITE, UU PDP, UU
+                    Perlindungan Konsumen, dan regulasi RI yang berlaku.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Bottom Navigation */}
+            <div className="pt-10 border-t border-border flex flex-col items-start gap-12 text-left cursor-pointer">
+              <Link href="/">
+                <button className="flex items-center gap-2 text-primary font-bold text-sm hover:opacity-70 transition-opacity ">
+                  <ArrowLeft className="w-4 h-4" />
+                  Kembali ke Beranda
+                </button>
+              </Link>
+              <p className="text-xs text-muted-foreground">
+                Dengan menggunakan SplitBill Online, Anda dianggap telah membaca
+                dan menyetujui Syarat & Ketentuan ini. Kami menyarankan Anda untuk
+                meninjau halaman ini secara berkala.
               </p>
             </div>
-          </div>
-
-          {/* Pasal 3 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 3 -</span>
-              Definisi
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Dalam Syarat dan Ketentuan ini, istilah-istilah berikut memiliki
-                makna sebagaimana didefinisikan:
-              </p>
-              <div className="space-y-3">
-                {[
-                  {
-                    k: "Platform",
-                    v: "Situs web https://splitbill.my.id beserta seluruh fitur dan layanan di dalamnya.",
-                  },
-                  {
-                    k: "Pengguna",
-                    v: "Individu yang mengakses Platform, baik dengan atau tanpa akun.",
-                  },
-                  {
-                    k: "Akun",
-                    v: "Akun yang didaftarkan melalui Google OAuth 2.0 untuk akses fitur tersimpan.",
-                  },
-                  {
-                    k: "Konten Pengguna",
-                    v: "Data, teks, atau gambar yang diunggah atau dibuat oleh Anda di Platform.",
-                  },
-                  {
-                    k: "Layanan",
-                    v: "Seluruh fitur dan fungsi yang disediakan oleh Pengelola melalui Platform.",
-                  },
-                  {
-                    k: "Data Pribadi",
-                    v: "Data tentang orang perseorangan sebagaimana didefinisikan dalam UU PDP.",
-                  },
-                ].map((item, i) => (
-                  <div key={i} className="flex gap-2">
-                    <span className="text-[#9ca3af] font-medium shrink-0">
-                      {String.fromCharCode(97 + i)}.
-                    </span>
-                    <p>
-                      <strong className="text-[#111827]">"{item.k}"</strong>{" "}
-                      berarti {item.v}
-                    </p>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-
-          {/* Pasal 4 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 4 -</span>
-              Ruang Lingkup Layanan
-            </h2>
-            <div className="space-y-6">
-              <div className="space-y-3">
-                <h3 className="font-bold text-[#374151]">
-                  4.1 Split Bill dan Pemindaian Struk
-                </h3>
-                <p>
-                  Fitur pembagian tagihan yang mengintegrasikan teknologi AI OCR
-                  (Optical Character Recognition) untuk mengekstraksi data
-                  nominal secara otomatis dari gambar struk fisik maupun
-                  digital.
-                </p>
-              </div>
-              <div className="space-y-3">
-                <h3 className="font-bold text-[#374151]">
-                  4.2 Invoice Digital
-                </h3>
-                <p>
-                  Fitur pembuatan tagihan digital sebagai sarana pencatatan dan
-                  dokumentasi pengeluaran bersama.
-                </p>
-              </div>
-              <div className="space-y-3">
-                <h3 className="font-bold text-[#374151]">
-                  4.3 Tujuan Bersama (Shared Goals)
-                </h3>
-                <p>
-                  Fitur pelacakan target keuangan bersama untuk memantau progres
-                  pencapaian tujuan kolektif.
-                </p>
-              </div>
-              <div className="space-y-3">
-                <h3 className="font-bold text-[#374151]">
-                  4.4 Pengumpulan Iuran (Collect Money)
-                </h3>
-                <p>
-                  Fitur manajemen iuran kelompok sebagai alat pembukuan digital
-                  untuk kebutuhan patungan atau kas bersama.
-                </p>
-              </div>
-              <div className="space-y-3">
-                <h3 className="font-bold text-[#374151]">
-                  4.5 Dompet Digital (Wallet)
-                </h3>
-                <p>
-                  Fitur pencatatan saldo pribadi yang berfungsi semata-mata
-                  sebagai alat pembukuan digital dan bukan dompet elektronik
-                  berizin Bank Indonesia.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* Pasal 5 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 5 -</span>
-              Sifat dan Batasan Layanan
-            </h2>
-            <div className="space-y-6">
-              <div className="space-y-3">
-                <h3 className="font-bold text-[#374151]">
-                  5.1 Bukan Lembaga Keuangan
-                </h3>
-                <p>
-                  Split Bill Online secara tegas bukan merupakan bank, lembaga
-                  keuangan, atau penyelenggara jasa pembayaran. Kami tidak
-                  menyimpan atau mengelola dana Pengguna secara aktual.
-                </p>
-              </div>
-              <div className="space-y-3">
-                <h3 className="font-bold text-[#374151]">
-                  5.2 Akurasi Kecerdasan Buatan
-                </h3>
-                <p>
-                  Fitur AI dikembangkan oleh pihak ketiga. Kami tidak menjamin
-                  akurasi 100% dan Pengguna wajib memverifikasi kembali seluruh
-                  data sebelum finalisasi. Pengelola tidak bertanggung jawab
-                  atas kesalahan ekstraksi sistem AI.
-                </p>
-              </div>
-              <div className="space-y-3">
-                <h3 className="font-bold text-[#374151]">
-                  5.3 Tanggung Jawab Pembayaran
-                </h3>
-                <p>
-                  Transaksi keuangan yang dicatat merupakan tanggung jawab
-                  pribadi antar Pengguna. Pengelola tidak bertanggung jawab atas
-                  gagal bayar atau sengketa antar Pengguna.
-                </p>
-              </div>
-              <div className="space-y-3">
-                <h3 className="font-bold text-[#374151]">
-                  5.4 Ketersediaan Layanan
-                </h3>
-                <p>
-                  Kami berupaya menyediakan layanan kontinu namun tidak menjamin
-                  kebebasan mutlak dari gangguan teknis atau pemeliharaan sistem
-                  sewaktu-waktu.
-                </p>
-              </div>
-              <div className="space-y-3">
-                <h3 className="font-bold text-[#374151]">
-                  5.5 Batasan Tanggung Jawab
-                </h3>
-                <p>
-                  Pengelola tidak bertanggung jawab atas kerugian tidak
-                  langsung, insidental, atau konsekuensial yang timbul dari
-                  penggunaan Platform.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* Pasal 6 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 6 -</span>
-              Pendaftaran dan Keamanan Akun
-            </h2>
-            <div className="space-y-4">
-              <div className="flex gap-2">
-                <span className="text-[#9ca3af] font-medium shrink-0">
-                  6.1.
-                </span>
-                <p>
-                  Fitur dasar dapat digunakan tanpa akun, di mana data disimpan
-                  secara lokal di perangkat Anda (local storage browser).
-                </p>
-              </div>
-              <div className="flex gap-2">
-                <span className="text-[#9ca3af] font-medium shrink-0">
-                  6.2.
-                </span>
-                <p>
-                  Sinkronisasi data lintas perangkat memerlukan pendaftaran akun
-                  melalui Google OAuth 2.0.
-                </p>
-              </div>
-              <div className="flex gap-2">
-                <span className="text-[#9ca3af] font-medium shrink-0">
-                  6.3.
-                </span>
-                <p>
-                  Pengguna bertanggung jawab penuh atas keamanan akses akun dan
-                  wajib melapor jika terjadi indikasi akses tidak sah.
-                </p>
-              </div>
-              <div className="flex gap-2">
-                <span className="text-[#9ca3af] font-medium shrink-0">
-                  6.4.
-                </span>
-                <p>
-                  Satu Pengguna hanya diperbolehkan memiliki satu akun aktif.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* Pasal 7 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 7 -</span>
-              Ketentuan Penggunaan yang Diizinkan
-            </h2>
-            <div className="space-y-4">
-              <p>Pengguna diizinkan menggunakan Platform untuk:</p>
-              <div className="space-y-2">
-                {[
-                  "Membagi tagihan sosial antar individu yang sah.",
-                  "Mengelola catatan keuangan kolaboratif non-komersial.",
-                  "Menggunakan AI OCR untuk membantu pencatatan nominal.",
-                  "Mengakses dan mengunduh riwayat transaksi pribadi.",
-                ].map((item, i) => (
-                  <div key={i} className="flex gap-2 pl-4">
-                    <span className="text-[#9ca3af] shrink-0">•</span>
-                    <p>{item}</p>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-
-          {/* Pasal 8 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 8 -</span>
-              Larangan Penggunaan
-            </h2>
-            <div className="space-y-6">
-              <div className="space-y-3">
-                <h3 className="font-bold text-[#374151]">
-                  8.1 Kegiatan Ilegal
-                </h3>
-                <p>
-                  Larangan keras atas pencucian uang, pendanaan terorisme, atau
-                  penipuan dalam bentuk apa pun.
-                </p>
-              </div>
-              <div className="space-y-3">
-                <h3 className="font-bold text-[#374151]">
-                  8.2 Manipulasi Data
-                </h3>
-                <p>
-                  Dilarang mengunggah struk palsu atau memanipulasi data untuk
-                  menyesatkan Pengguna lain.
-                </p>
-              </div>
-              <div className="space-y-3">
-                <h3 className="font-bold text-[#374151]">
-                  8.3 Gangguan Sistem
-                </h3>
-                <p>
-                  Dilarang melakukan rekayasa balik (reverse engineering) atau
-                  meretas infrastruktur teknis Platform.
-                </p>
-              </div>
-              <div className="space-y-3">
-                <h3 className="font-bold text-[#374151]">
-                  8.4 Konten Terlarang
-                </h3>
-                <p>
-                  Dilarang mengunggah konten SARA, pornografi, kekerasan, atau
-                  ujaran kebencian.
-                </p>
-              </div>
-              <p className="text-sm font-medium text-destructive/80 italic">
-                Pelanggaran berat dapat mengakibatkan penghapusan akun permanen
-                dan tindakan hukum sesuai regulasi RI.
-              </p>
-            </div>
-          </div>
-
-          {/* Pasal 9 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 9 -</span>
-              Hak Kekayaan Intelektual
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Seluruh desain, kode program, logo, dan merek dagang merupakan
-                milik eksklusif{" "}
-                <strong className="text-[#111827]">Split Bill Online</strong>{" "}
-                dan dilindungi UU Hak Cipta & UU Merek Republik Indonesia.
-                Pengguna diberikan lisensi terbatas hanya untuk penggunaan
-                pribadi non-komersial.
-              </p>
-            </div>
-          </div>
-
-          {/* Pasal 10 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 10 -</span>
-              Perlindungan Data Pribadi
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Pemrosesan data dilaksanakan sesuai UU PDP dan Kebijakan Privasi
-                Kami. Kebijakan Privasi merupakan bagian tidak terpisahkan dari
-                Syarat & Ketentuan ini.
-              </p>
-            </div>
-          </div>
-
-          {/* Pasal 11 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 11 -</span>
-              Layanan Pihak Ketiga
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Penggunaan integrasi Google OAuth, Cloud, dan AI tunduk pada
-                ketentuan masing-masing penyedia. Kami tidak bertanggung jawab
-                atas konten atau praktik layanan pihak ketiga tersebut.
-              </p>
-            </div>
-          </div>
-
-          {/* Pasal 12 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 12 -</span>
-              Penangguhan dan Penghentian Akun
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Kami berhak menghapus akun yang melanggar ketentuan. Pengguna
-                juga dapat meminta penghapusan akun kapan saja melalui surel
-                legal, dengan proses penyelesaian maksimal 30 hari kalender.
-              </p>
-            </div>
-          </div>
-
-          {/* Pasal 13 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 13 -</span>
-              Pembaruan Syarat dan Ketentuan
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Pembaruan dilakukan sewaktu-waktu. Perubahan material akan
-                diberitahukan 14 hari sebelumnya. Penggunaan berlanjut dianggap
-                sebagai persetujuan atas versi terbaru.
-              </p>
-            </div>
-          </div>
-
-          {/* Pasal 14 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 14 -</span>
-              Ganti Rugi (Indemnifikasi)
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Pengguna setuju untuk membebaskan Pengelola dari segala klaim
-                atau tuntutan hukum yang timbul akibat penyalahgunaan Platform
-                atau pelanggaran hak pihak ketiga oleh Pengguna.
-              </p>
-            </div>
-          </div>
-
-          {/* Pasal 15 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 15 -</span>
-              Hukum dan Penyelesaian Sengketa
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Tunduk pada hukum Republik Indonesia. Sengketa diselesaikan
-                secara musyawarah (30 hari), mediasi, dan terakhir melalui
-                litigasi di Pengadilan Negeri Jakarta Pusat.
-              </p>
-            </div>
-          </div>
-
-          {/* Pasal 16 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 16 -</span>
-              Ketentuan Lain-Lain
-            </h2>
-            <div className="space-y-4">
-              <p>
-                Mencakup ketentuan mengenai keterpisahan (severability), tidak
-                adanya pengesampingan hak, keseluruhan perjanjian, pengalihan
-                hak, dan keadaan kahar (force majeure).
-              </p>
-            </div>
-          </div>
-
-          {/* Pasal 17 */}
-          <div className="space-y-4">
-            <h2 className="text-lg font-bold text-[#374151] flex gap-2">
-              <span className="text-[#9ca3af] font-medium">Pasal 17 -</span>
-              Informasi Kontak
-            </h2>
-            <div className="space-y-4 text-left">
-              <p>
-                <strong className="text-[#111827]">Pengelola:</strong> Split
-                Bill Online
-                <br />
-                <strong className="text-[#111827]">Situs Web:</strong>{" "}
-                https://splitbill.my.id
-                <br />
-                <strong className="text-[#111827]">Surel:</strong>{" "}
-                <a
-                  href="mailto:legal@splitbill.my.id"
-                  className="text-primary font-bold hover:underline"
-                >
-                  legal@splitbill.my.id
-                </a>
-              </p>
-              <div className="pt-4 space-y-1">
-                <p className="text-sm font-bold text-[#111827]">
-                  Syarat dan Ketentuan ini berlaku sejak 16 Mei 2026
-                </p>
-                <p className="text-xs">
-                  © 2026 Split Bill Online - splitbill.my.id
-                </p>
-                <p className="text-[10px] italic">
-                  Dokumen ini disusun sesuai dengan UU ITE, UU PDP, UU
-                  Perlindungan Konsumen, dan regulasi RI yang berlaku.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* Bottom Navigation */}
-          <div className="pt-10 border-t border-border flex flex-col items-start gap-12 text-left cursor-pointer">
-            <Link href="/">
-              <button className="flex items-center gap-2 text-primary font-bold text-sm hover:opacity-70 transition-opacity ">
-                <ArrowLeft className="w-4 h-4" />
-                Kembali ke Beranda
-              </button>
-            </Link>
-            <p className="text-xs text-muted-foreground">
-              Dengan menggunakan SplitBill Online, Anda dianggap telah membaca
-              dan menyetujui Syarat & Ketentuan ini. Kami menyarankan Anda untuk
-              meninjau halaman ini secara berkala.
-            </p>
-          </div>
-        </motion.div>
+          </motion.div>
+        </div>
       </main>
 
+      <HomepageFooter />
       <Footer />
     </div>
   );

--- a/src/components/blog/BlogCTA.tsx
+++ b/src/components/blog/BlogCTA.tsx
@@ -29,28 +29,44 @@ export const BlogCTA = () => {
   ];
 
   return (
-    <section className="w-full max-w-[600px] mx-auto bg-muted/20 py-12 px-8 rounded-t-lg">
-      <div className=" mx-auto text-left">
-        <h2 className="text-2xl font-black text-primary leading-tight mb-2">
-          3 Langkah Mudah Bagi Tagihan <br />
-          <span className="text-foreground">#PakeSplitBill</span>
-        </h2>
-        <p className="text-muted-foreground text-sm mb-10">
-          Urus patungan jadi lebih cepat, adil, dan transparan.
-        </p>
+    <section className="w-full max-w-[600px] lg:max-w-7xl mx-auto py-12 lg:py-16 px-6">
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-8 lg:gap-12 items-center">
+        {/* Kolom 1: Title, Desc, and CTA (Lebih lebar dengan col-span-2) */}
+        <div className="col-span-1 lg:col-span-2 flex flex-col text-left lg:h-full lg:justify-between gap-6 lg:pr-8">
+          <div className="space-y-3">
+            <h2 className="text-2xl lg:text-3xl font-black text-primary leading-tight">
+              3 Langkah Mudah Bagi Tagihan <br />
+              <span className="text-foreground">#PakeSplitBill</span>
+            </h2>
+            <p className="text-muted-foreground text-sm">
+              Urus patungan jadi lebih cepat, adil, dan transparan.
+            </p>
+          </div>
+          <Link href="/split-bill" className="w-full cursor-pointer">
+            <motion.button
+              whileHover={{ scale: 1.02 }}
+              whileTap={{ scale: 0.98 }}
+              className="w-full lg:max-w-xs bg-primary text-white font-bold py-3.5 px-6 rounded-2xl shadow-glow flex items-center justify-center gap-2 group transition-all cursor-pointer text-sm"
+            >
+              Coba Split Bill
+              <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-1" />
+            </motion.button>
+          </Link>
+        </div>
 
-        <div className="space-y-8 mb-12">
+        {/* Kolom 2, 3, 4: Langkah-langkah (col-span-3) */}
+        <div className="col-span-1 lg:col-span-3 grid grid-cols-1 md:grid-cols-3 gap-6 lg:gap-8">
           {steps.map((step, index) => {
             const Icon = step.icon;
             return (
-              <div key={index} className="flex gap-4">
+              <div key={index} className="flex lg:flex-col gap-4 lg:justify-start">
                 <div
                   className={`flex-shrink-0 w-12 h-12 rounded-2xl ${step.color} flex items-center justify-center`}
                 >
                   <Icon className="w-6 h-6" />
                 </div>
-                <div className="space-y-1">
-                  <h3 className="font-bold text-foreground text-base leading-none">
+                <div className="space-y-1 text-left lg:mt-1">
+                  <h3 className="font-bold text-foreground text-base leading-tight">
                     {step.title}
                   </h3>
                   <p className="text-xs text-muted-foreground leading-relaxed">
@@ -61,17 +77,6 @@ export const BlogCTA = () => {
             );
           })}
         </div>
-
-        <Link href="/split-bill">
-          <motion.button
-            whileHover={{ scale: 1.02 }}
-            whileTap={{ scale: 0.98 }}
-            className="w-full bg-primary text-white font-bold py-4 rounded-2xl shadow-glow flex items-center justify-center gap-2 group transition-all"
-          >
-            Coba Split Bill Sekarang
-            <ArrowRight className="w-5 h-5 transition-transform group-hover:translate-x-1" />
-          </motion.button>
-        </Link>
       </div>
     </section>
   );

--- a/src/components/homepage/BlogSectionHomepage.tsx
+++ b/src/components/homepage/BlogSectionHomepage.tsx
@@ -125,7 +125,6 @@ export const BlogSectionHomepage = () => {
                     whileInView={{ opacity: 1, y: 0 }}
                     viewport={{ once: true, margin: "-30px" }}
                     transition={{ duration: 0.5, delay: idx * 0.05, ease: "easeOut" }}
-                    style={{ willChange: "transform, opacity" }}
                     className="flex-shrink-0 w-[290px] sm:w-[350px] snap-start"
                   >
                     <BlogCard blog={blog} />

--- a/src/components/homepage/CTABannerSection.tsx
+++ b/src/components/homepage/CTABannerSection.tsx
@@ -69,7 +69,6 @@ export const CTABannerSection = () => {
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true, margin: "-100px" }}
             transition={{ duration: 0.5 }}
-            style={{ willChange: "transform, opacity" }}
             className="flex flex-col items-center lg:items-start text-center lg:text-left lg:col-span-7"
           >
             <h2 className="text-3xl sm:text-4xl md:text-5xl font-black text-slate-900 tracking-tight leading-tight mb-6">
@@ -116,7 +115,6 @@ export const CTABannerSection = () => {
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true, margin: "-100px" }}
             transition={{ duration: 0.6, delay: 0.1 }}
-            style={{ willChange: "transform, opacity" }}
             className="flex flex-col gap-4 lg:col-span-5 w-full"
           >
             {cards.map((card, idx) => {
@@ -128,8 +126,7 @@ export const CTABannerSection = () => {
                   viewport={{ once: true }}
                   transition={{ duration: 0.4, delay: 0.1 * idx }}
                   whileHover={{ x: 6, scale: 1.02 }}
-                  style={{ willChange: "transform, opacity" }}
-                  className={`flex gap-4 p-5 sm:p-6 rounded-2xl bg-white/70 backdrop-blur-md border ${card.bg} shadow-[0_8px_30px_rgb(0,0,0,0.02)] hover:shadow-[0_12px_40px_rgba(71,159,234,0.06)] transition-all duration-300`}
+                  className={`flex gap-4 p-5 sm:p-6 rounded-2xl bg-white/70 backdrop-blur-md border ${card.bg} shadow-[0_8px_30px_rgb(0,0,0,0.02)] hover:shadow-[0_12px_40px_rgba(71,159,234,0.06)] transition-[box-shadow,border-color,background-color] duration-300`}
                 >
                   <div className={`flex-shrink-0 w-12 h-12 rounded-lg ${card.bgLight} ${card.bgHover} flex items-center justify-center p-1 transition-all duration-300 group-hover:scale-105`}>
                     <img

--- a/src/components/homepage/ComparisonSection.tsx
+++ b/src/components/homepage/ComparisonSection.tsx
@@ -62,8 +62,8 @@ export const ComparisonSection = () => {
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true, margin: "-50px" }}
             transition={{ duration: 0.6 }}
-            style={{ willChange: "transform, opacity" }}
-            className="bg-rose-50/50 border border-rose-100/80 rounded-3xl p-6 sm:p-8 hover:shadow-[0_12px_30px_-6px_rgba(244,63,94,0.15)] hover:border-rose-400/70 hover:-translate-y-1.5 transition-all duration-300 cursor-pointer"
+            whileHover={{ y: -6 }}
+            className="bg-rose-50/50 border border-rose-100/80 rounded-3xl p-6 sm:p-8 hover:shadow-[0_12px_30px_-6px_rgba(244,63,94,0.15)] hover:border-rose-400/70 transition-[box-shadow,border-color,background-color] duration-300 cursor-pointer"
           >
             <div className="flex items-center gap-2 mb-6">
               <span className="text-2xl">😩</span>
@@ -71,7 +71,7 @@ export const ComparisonSection = () => {
                 Sebelum pake SplitBill
               </h3>
             </div>
-
+ 
             <ul className="space-y-4">
               {withoutSplitBill.map((item, idx) => (
                 <li key={idx} className="flex items-start gap-3">
@@ -83,15 +83,15 @@ export const ComparisonSection = () => {
               ))}
             </ul>
           </motion.div>
-
+ 
           {/* With SplitBill Card */}
           <motion.div
             initial={{ opacity: 0, x: 30 }}
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true, margin: "-50px" }}
             transition={{ duration: 0.6 }}
-            style={{ willChange: "transform, opacity" }}
-            className="bg-emerald-50/50 border border-emerald-300 rounded-3xl p-6 sm:p-8 hover:shadow-[0_12px_30px_-6px_rgba(16,185,129,0.15)] hover:border-emerald-400 hover:-translate-y-1.5 transition-all duration-300 relative overflow-hidden cursor-pointer"
+            whileHover={{ y: -6 }}
+            className="bg-emerald-50/50 border border-emerald-300 rounded-3xl p-6 sm:p-8 hover:shadow-[0_12px_30px_-6px_rgba(16,185,129,0.15)] hover:border-emerald-400 transition-[box-shadow,border-color,background-color] duration-300 relative overflow-hidden cursor-pointer"
           >
             {/* Glow badge */}
             <div className="absolute top-0 right-0 bg-emerald-500 text-white text-[10px] font-black px-4 py-1.5 rounded-bl-2xl uppercase tracking-wider">

--- a/src/components/homepage/FAQSectionHomepage.tsx
+++ b/src/components/homepage/FAQSectionHomepage.tsx
@@ -57,8 +57,7 @@ export const FAQSectionHomepage = () => {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, margin: "-50px" }}
                 transition={{ duration: 0.4, delay: index * 0.08 }}
-                style={{ willChange: "transform, opacity" }}
-                className="bg-white border border-slate-100 rounded-2xl overflow-hidden shadow-[0_4px_20px_-6px_rgba(0,0,0,0.02)] hover:shadow-[0_8px_24px_-6px_rgba(0,0,0,0.05)] hover:border-slate-200/80 transition-all duration-300"
+                className="bg-white border border-slate-100 rounded-2xl overflow-hidden shadow-[0_4px_20px_-6px_rgba(0,0,0,0.02)] hover:shadow-[0_8px_24px_-6px_rgba(0,0,0,0.05)] hover:border-slate-200/80 transition-[box-shadow,border-color,background-color] duration-300"
               >
                 <button
                   onClick={() => toggleFaq(faq.id)}

--- a/src/components/homepage/FeaturesSection.tsx
+++ b/src/components/homepage/FeaturesSection.tsx
@@ -136,7 +136,6 @@ export const FeaturesSection = () => {
               <motion.div
                 key={feat.title}
                 variants={cardVariants}
-                style={{ willChange: "transform, opacity" }}
                 className="h-full"
               >
                 <Link href={feat.href} className="block h-full">

--- a/src/components/homepage/HomepageNavbar.tsx
+++ b/src/components/homepage/HomepageNavbar.tsx
@@ -10,6 +10,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { useAuthStore } from "@/lib/stores/authStore";
 import { usePWA } from "@/hooks/usePWA";
 import { toast } from "sonner";
+import { usePathname, useRouter } from "next/navigation";
 
 const navLinks = [
   { label: "Fitur", href: "#fitur" },
@@ -19,6 +20,8 @@ const navLinks = [
 ];
 
 export const HomepageNavbar = () => {
+  const pathname = usePathname();
+  const router = useRouter();
   const [scrolled, setScrolled] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [headerHeight, setHeaderHeight] = useState(64);
@@ -91,9 +94,13 @@ export const HomepageNavbar = () => {
   ) => {
     if (href.startsWith("#")) {
       e.preventDefault();
-      const el = document.getElementById(href.slice(1));
-      if (el) {
-        el.scrollIntoView({ behavior: "smooth", block: "start" });
+      if (pathname === "/") {
+        const el = document.getElementById(href.slice(1));
+        if (el) {
+          el.scrollIntoView({ behavior: "smooth", block: "start" });
+        }
+      } else {
+        router.push(`/${href}`);
       }
       setMenuOpen(false);
     }
@@ -165,7 +172,7 @@ export const HomepageNavbar = () => {
               {navLinks.map((link) => (
                 <a
                   key={link.href}
-                  href={link.href}
+                  href={pathname === "/" ? link.href : `/${link.href}`}
                   onClick={(e) => handleNavClick(e, link.href)}
                   className="px-4 py-2 rounded-sm text-sm font-semibold text-slate-700 hover:text-primary hover:bg-slate-100 transition-all duration-200 cursor-pointer"
                 >
@@ -269,7 +276,7 @@ export const HomepageNavbar = () => {
               {navLinks.map((link) => (
                 <a
                   key={link.href}
-                  href={link.href}
+                  href={pathname === "/" ? link.href : `/${link.href}`}
                   onClick={(e) => handleNavClick(e, link.href)}
                   className="px-4 py-3 rounded-xl text-base font-semibold text-slate-700 hover:text-primary hover:bg-primary/5 transition-all duration-200 cursor-pointer"
                 >

--- a/src/components/homepage/HowItWorksSection.tsx
+++ b/src/components/homepage/HowItWorksSection.tsx
@@ -110,7 +110,6 @@ export const HowItWorksSection = () => {
                     whileInView={{ opacity: 1, y: 0 }}
                     viewport={{ once: true, margin: "-30px" }}
                     transition={{ duration: 0.5, delay: index * 0.1, ease: "easeOut" }}
-                    style={{ willChange: "transform, opacity" }}
                     className="flex-shrink-0 w-[82vw] snap-center flex flex-col items-center text-center"
                   >
                     {/* Image */}
@@ -171,7 +170,6 @@ export const HowItWorksSection = () => {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, margin: "-50px" }}
                 transition={{ duration: 0.6, delay: index * 0.15 }}
-                style={{ willChange: "transform, opacity" }}
                 className="flex flex-col items-center text-center group"
               >
                 {/* Image Showcase */}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { ArrowLeft, LogIn, MessageCircle, Crown } from "lucide-react";
+import { ArrowLeft, LogIn, MessageCircle, Crown, Smartphone } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { cn } from "@/lib/utils";
 import { useAuthStore } from "@/lib/stores/authStore";
@@ -56,6 +56,12 @@ export const Header = ({
         className,
       )}
     >
+      {!wide && (
+        <div className="hidden lg:flex w-full items-center justify-center gap-2 bg-amber-50 px-4 py-2 text-amber-800 text-xs font-medium">
+          <Smartphone className="w-3.5 h-3.5 shrink-0" />
+          <span>Biar lebih sat-set, mending buka web ini di HP aja guys! 📱✨</span>
+        </div>
+      )}
       <div
         className={cn(
           "w-full mx-auto text-white transition-colors duration-300 pt-safe",

--- a/src/components/layout/ResponsiveShell.tsx
+++ b/src/components/layout/ResponsiveShell.tsx
@@ -16,9 +16,11 @@ export const ResponsiveShell = ({ children }: ResponsiveShellProps) => {
     setIsMounted(true);
   }, []);
 
+  const isBlogDetail = pathname.startsWith("/blog/") && pathname.split("/").length > 2;
+
   return (
     <div className="w-full min-h-screen bg-background">
-      {pathname !== "/" && <MemberSidebar />}
+      {pathname !== "/" && !isBlogDetail && <MemberSidebar />}
       {children}
     </div>
   );


### PR DESCRIPTION
- Replace <Header> with HomepageNavbar on /blog, /privacy, and /terms for consistent branding across all content pages
- Add pt-16 lg:pt-18 to page wrappers to offset fixed HomepageNavbar
- Replace SiteFooter with HomepageFooter (full-width version) on /privacy and /terms to match landing page and /blog footer style
- Align /privacy and /terms content card to max-w-7xl, max-w-none, sm:p-14 and rounded-lg to match BlogDetailClient layout
- Apply sidebar nav style rounded-[2px] and remove shadow-sm from content card on both legal pages
- Add section IDs and scroll-mt-28 offsets to all pasal divs on /terms to enable Table of Contents highlighting

fix: handle HomepageNavbar anchor links from non-homepage routes

- Detect current pathname using usePathname()
- On pathname === '/' perform smooth in-page scroll to anchor section
- On other pages, navigate to /#section via router.push() so browser lands on the correct landing-page section

fix: resolve scroll flicker on landing page sections

- Remove will-change: transform, opacity inline styles from FeaturesSection, HowItWorksSection, ComparisonSection, FAQSectionHomepage, BlogSectionHomepage, and CTABannerSection
- Replace transition-all with targeted transition-[box-shadow, border-color,background-color] on hover cards to prevent Framer Motion / CSS transition conflicts
- Move hover lift animations (hover:-translate-y-1.5) to Framer Motion whileHover={{ y: -6 }} on ComparisonSection cards