### PR TITLE
Uploaded struk display, receipt scan polish, splitbill UX fixes

### DIFF
--- a/src/app/split-bill/SplitBillClientPage.tsx
+++ b/src/app/split-bill/SplitBillClientPage.tsx
@@ -23,7 +23,7 @@ import { useWalletStore, type PaymentMethod } from "@/store/useWalletStore";
 import { useBillCalculations } from "@/hooks/useBillCalculations";
 import { WalletSelectionCard } from "@/components/wallet/WalletSelectionCard";
 import { AddPaymentMethodBottomSheet } from "@/components/wallet/AddPaymentMethodBottomSheet";
-import { draftApi, splitBillApi, mapFrontendToBackend } from "@/lib/api/split-bills";
+import { draftApi, splitBillApi, mapFrontendToBackend, receiptImageApi, parseDataUrlImages } from "@/lib/api/split-bills";
 import {
   Users,
   ReceiptText,
@@ -360,6 +360,26 @@ const SplitBillContent = () => {
             additionalExpenses: backendAdditionalExpenses,
             participants: backendParticipants,
           });
+
+          // Upload any receipt photos scanned so far, tied to this draft.
+          // Non-blocking: image storage is supplementary, so a failure here
+          // must never stop the user from advancing to Step 3.
+          const { scannedReceiptImages, clearScannedReceiptImages, addUploadedReceiptImages } =
+            useSplitBillStore.getState();
+          if (scannedReceiptImages.length > 0) {
+            const imagesPayload = parseDataUrlImages(scannedReceiptImages);
+            if (imagesPayload.length > 0) {
+              try {
+                const uploadRes = await receiptImageApi.upload(activeDraftId, imagesPayload);
+                if (uploadRes.success && Array.isArray(uploadRes.images)) {
+                  addUploadedReceiptImages(uploadRes.images);
+                }
+                clearScannedReceiptImages();
+              } catch (uploadErr) {
+                console.error("Failed to upload receipt images:", uploadErr);
+              }
+            }
+          }
         }
       } else if (step === 3) {
         let activeDraftId = draftId;

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -8,6 +8,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useSplitBillStore } from "@/store/useSplitBillStore";
 import { useAuthStore } from "@/lib/stores/authStore";
 import { toast } from "sonner";
+import { compressImageFile } from "@/lib/utils/imageCompress";
 
 export const Footer = () => {
   const pathname = usePathname();
@@ -58,17 +59,23 @@ export const Footer = () => {
       const file = e.target.files?.[0];
       if (!file) return;
 
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        const base64 = reader.result as string;
-        setPendingCapturedImage(base64);
+      const onCaptured = (dataUrl: string) => {
+        setPendingCapturedImage(dataUrl);
         toast.success("Foto tersimpan! 📸", {
           description: "Tambahkan teman dulu, lalu lanjut ke scan AI.",
           duration: 3000,
         });
         router.push("/split-bill?step=1");
       };
-      reader.readAsDataURL(file);
+
+      compressImageFile(file)
+        .then(onCaptured)
+        .catch((err) => {
+          console.warn("Image compression failed, using original file:", err);
+          const reader = new FileReader();
+          reader.onloadend = () => onCaptured(reader.result as string);
+          reader.readAsDataURL(file);
+        });
 
       // Reset so the same file can be re-selected
       e.target.value = "";

--- a/src/components/layout/MemberSidebar.tsx
+++ b/src/components/layout/MemberSidebar.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { useSplitBillStore } from "@/store/useSplitBillStore";
 import { useAuthStore } from "@/lib/stores/authStore";
 import { toast } from "sonner";
+import { compressImageFile } from "@/lib/utils/imageCompress";
 
 export const MemberSidebar = () => {
   const pathname = usePathname();
@@ -25,17 +26,24 @@ export const MemberSidebar = () => {
       const file = e.target.files?.[0];
       if (!file) return;
 
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        const base64 = reader.result as string;
-        setPendingCapturedImage(base64);
+      const onCaptured = (dataUrl: string) => {
+        setPendingCapturedImage(dataUrl);
         toast.success("Foto tersimpan! 📸", {
           description: "Tambahkan teman dulu, lalu lanjut ke scan AI.",
           duration: 3000,
         });
         router.push("/split-bill?step=1");
       };
-      reader.readAsDataURL(file);
+
+      compressImageFile(file)
+        .then(onCaptured)
+        .catch((err) => {
+          console.warn("Image compression failed, using original file:", err);
+          const reader = new FileReader();
+          reader.onloadend = () => onCaptured(reader.result as string);
+          reader.readAsDataURL(file);
+        });
+
       e.target.value = "";
     },
     [setPendingCapturedImage, router],

--- a/src/components/splitbill/AIScanForm.tsx
+++ b/src/components/splitbill/AIScanForm.tsx
@@ -134,7 +134,7 @@ export const AIScanForm = ({ onLoginClick }: { onLoginClick?: () => void }) => {
       result.items.forEach((item: ReceiptItem) => {
         addExpense({
           item: item.name,
-          amount: item.price * (item.quantity || 1),
+          amount: item.price,
           who: [],
           paidBy: "",
         });
@@ -318,7 +318,7 @@ export const AIScanForm = ({ onLoginClick }: { onLoginClick?: () => void }) => {
       scanResult.items.forEach((item: ReceiptItem) => {
         addExpense({
           item: item.name,
-          amount: item.price * (item.quantity || 1),
+          amount: item.price,
           who: [],
           paidBy: "",
         });
@@ -635,7 +635,7 @@ export const AIScanForm = ({ onLoginClick }: { onLoginClick?: () => void }) => {
                           </span>
                         </div>
                         <span className="font-black text-foreground shrink-0">
-                          {formatCurrency(item.price * item.quantity)}
+                          {formatCurrency(item.price)}
                         </span>
                       </div>
                     ))}

--- a/src/components/splitbill/BillSummary.tsx
+++ b/src/components/splitbill/BillSummary.tsx
@@ -37,6 +37,8 @@ import { trackSplitBill, trackWallet } from "@/lib/gtag";
 import { useAuthStore } from "@/lib/stores/authStore";
 import { AuthModal } from "@/components/auth/AuthModal";
 import { SecureDraftBanner } from "./SecureDraftBanner";
+import { UploadedStrukSection } from "./UploadedStrukSection";
+import { BackendReceiptImage } from "@/lib/api/split-bills";
 
 export interface BillSummaryHandle {
   triggerShare: () => void;
@@ -51,6 +53,7 @@ interface BillSummaryProps {
     date: string;
     selectedPaymentMethodIds?: string[];
     paymentMethodSnapshots?: any[];
+    receiptImages?: BackendReceiptImage[];
   };
   showDownload?: boolean;
   isPublic?: boolean;
@@ -96,6 +99,9 @@ export const BillSummary = React.forwardRef<BillSummaryHandle, BillSummaryProps>
       ? billData.additionalExpenses
       : store.additionalExpenses;
     const activityName = billData ? billData.activityName : store.activityName;
+    const receiptImages = billData
+      ? billData.receiptImages || []
+      : store.uploadedReceiptImages;
     const selectedPaymentMethodIds = billData
       ? billData.selectedPaymentMethodIds || []
       : store.selectedPaymentMethodIds;
@@ -758,6 +764,16 @@ export const BillSummary = React.forwardRef<BillSummaryHandle, BillSummaryProps>
                   </div>
                 </div>
               )}
+            </div>
+          </Card>
+        )}
+
+        {/* Uploaded Struk Card */}
+        {receiptImages.length > 0 && (
+          <Card className="p-3 shadow-md overflow-hidden relative">
+            <div className="absolute top-0 right-0 w-32 h-32 bg-primary/5 rounded-full -mr-16 -mt-16 blur-3xl pointer-events-none" />
+            <div className="relative z-10">
+              <UploadedStrukSection images={receiptImages} />
             </div>
           </Card>
         )}

--- a/src/components/splitbill/UploadedStrukSection.tsx
+++ b/src/components/splitbill/UploadedStrukSection.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import {
+  Eye,
+  ImageOff,
+  ArrowLeft,
+  ChevronLeft,
+  ChevronRight,
+  ZoomIn,
+  ZoomOut,
+  Maximize2,
+} from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { cn, formatRelativeTime } from "@/lib/utils";
+import { BackendReceiptImage } from "@/lib/api/split-bills";
+import { API_BASE_URL } from "@/lib/constants";
+
+interface UploadedStrukSectionProps {
+  images: BackendReceiptImage[];
+}
+
+/** Backend may return a path relative to its own origin (e.g. "/api/split-bills/.../images/...");
+ *  resolve it against the API host instead of letting the browser default to the frontend origin. */
+const resolveImageUrl = (url: string) =>
+  url.startsWith("/") ? `${API_BASE_URL}${url}` : url;
+
+const getFileName = (url: string, mimeType: string, idx: number) => {
+  try {
+    const path = new URL(url, API_BASE_URL).pathname;
+    const base = path.substring(path.lastIndexOf("/") + 1);
+    if (base) return decodeURIComponent(base);
+  } catch {
+    // malformed URL, fall through to generated name
+  }
+  const ext = mimeType?.split("/")[1] || "jpg";
+  return `Struk-${idx + 1}.${ext}`;
+};
+
+export const UploadedStrukSection: React.FC<UploadedStrukSectionProps> = ({
+  images,
+}) => {
+  const [viewerIndex, setViewerIndex] = useState<number | null>(null);
+  const [brokenIds, setBrokenIds] = useState<Set<string>>(new Set());
+
+  if (!images || images.length === 0) return null;
+
+  const markBroken = (key: string) =>
+    setBrokenIds((prev) => new Set(prev).add(key));
+
+  return (
+    <>
+      <div className="space-y-1">
+        <h3 className="font-bold text-xs text-foreground/70 uppercase px-1">
+          Struk Diunggah 🧾
+        </h3>
+        <p className="text-[10px] text-muted-foreground font-medium px-1">
+          Struk hanya tersedia selama 7 hari sejak diunggah.
+        </p>
+      </div>
+      <div className="divide-y divide-dashed divide-primary/10 px-1 mt-2">
+        {images.map((img, idx) => {
+          const key = img.id || String(idx);
+          const isDeleted = brokenIds.has(key);
+
+          return (
+            <div key={key} className="py-2.5 flex items-center gap-3">
+              {isDeleted ? (
+                <div className="w-12 h-12 rounded-xs bg-muted/30 border border-dashed border-muted-foreground/30 shrink-0 flex items-center justify-center">
+                  <ImageOff className="w-5 h-5 text-muted-foreground" />
+                </div>
+              ) : (
+                <button
+                  onClick={() => setViewerIndex(idx)}
+                  className="w-12 h-12 rounded-xs overflow-hidden bg-white border border-primary/10 shrink-0 cursor-pointer"
+                >
+                  <img
+                    src={resolveImageUrl(img.url)}
+                    alt={`Struk ${idx + 1}`}
+                    className="w-full h-full object-cover"
+                    onError={() => markBroken(key)}
+                  />
+                </button>
+              )}
+              <div className="min-w-0 flex-1">
+                <p
+                  className={cn(
+                    "text-xs font-bold truncate",
+                    isDeleted
+                      ? "text-muted-foreground line-through"
+                      : "text-foreground",
+                  )}
+                >
+                  {getFileName(img.url, img.mimeType, idx)}
+                </p>
+                <p
+                  className={cn(
+                    "text-[10px] font-medium",
+                    isDeleted ? "text-destructive" : "text-muted-foreground",
+                  )}
+                >
+                  {isDeleted
+                    ? "Struk sudah dihapus"
+                    : formatRelativeTime(img.uploadedAt)}
+                </p>
+              </div>
+              {isDeleted ? (
+                <div
+                  title="Struk sudah dihapus"
+                  className="shrink-0 w-8 h-8 flex items-center justify-center rounded-full bg-muted/30 text-muted-foreground"
+                >
+                  <ImageOff className="w-4 h-4" />
+                </div>
+              ) : (
+                <button
+                  onClick={() => setViewerIndex(idx)}
+                  title="Lihat Struk"
+                  className="shrink-0 w-8 h-8 flex items-center justify-center rounded-full bg-primary/10 text-primary hover:bg-primary/20 transition-colors cursor-pointer"
+                >
+                  <Eye className="w-4 h-4" />
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {viewerIndex !== null && (
+        <ReceiptFullscreenViewer
+          images={images}
+          initialIndex={viewerIndex}
+          onClose={() => setViewerIndex(null)}
+        />
+      )}
+    </>
+  );
+};
+
+interface ReceiptFullscreenViewerProps {
+  images: BackendReceiptImage[];
+  initialIndex: number;
+  onClose: () => void;
+}
+
+const ReceiptFullscreenViewer: React.FC<ReceiptFullscreenViewerProps> = ({
+  images,
+  initialIndex,
+  onClose,
+}) => {
+  const [currentIndex, setCurrentIndex] = useState(initialIndex);
+  const [scale, setScale] = useState(1);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+  const [brokenIndexes, setBrokenIndexes] = useState<Set<number>>(new Set());
+  const dragStart = useRef({ x: 0, y: 0 });
+
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "unset";
+    };
+  }, []);
+
+  const goToIndex = (idx: number) => {
+    setCurrentIndex(idx);
+    setScale(1);
+    setPosition({ x: 0, y: 0 });
+  };
+
+  const activeImage = images[currentIndex];
+
+  const handleZoomIn = () => setScale((prev) => Math.min(prev + 0.25, 4));
+  const handleZoomOut = () => setScale((prev) => Math.max(prev - 0.25, 1));
+  const handleResetZoom = () => {
+    setScale(1);
+    setPosition({ x: 0, y: 0 });
+  };
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    if (scale === 1) return;
+    e.preventDefault();
+    setIsDragging(true);
+    dragStart.current = { x: e.clientX - position.x, y: e.clientY - position.y };
+  };
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!isDragging) return;
+    setPosition({ x: e.clientX - dragStart.current.x, y: e.clientY - dragStart.current.y });
+  };
+
+  const handleMouseUpOrLeave = () => setIsDragging(false);
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    if (scale === 1 || e.touches.length !== 1) return;
+    const touch = e.touches[0];
+    setIsDragging(true);
+    dragStart.current = { x: touch.clientX - position.x, y: touch.clientY - position.y };
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (!isDragging || e.touches.length !== 1) return;
+    const touch = e.touches[0];
+    setPosition({ x: touch.clientX - dragStart.current.x, y: touch.clientY - dragStart.current.y });
+  };
+
+  const handlePrev = () =>
+    goToIndex(currentIndex > 0 ? currentIndex - 1 : images.length - 1);
+  const handleNext = () =>
+    goToIndex(currentIndex < images.length - 1 ? currentIndex + 1 : 0);
+
+  return createPortal(
+    <div className="fixed inset-0 z-[100] flex justify-center pointer-events-auto">
+      {/* Full screen page — same treatment as AddPaymentMethodBottomSheet */}
+      <div
+        className={cn(
+          "absolute inset-0 w-full max-w-[600px] mx-auto bg-background flex flex-col",
+          "animate-in slide-in-from-bottom-full duration-300 ease-out",
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-primary/5 bg-background/95 backdrop-blur-sm sticky top-0 z-10 shrink-0">
+          <div className="flex items-center gap-2">
+            <button
+              onClick={onClose}
+              className="p-2 -ml-2 text-muted-foreground hover:text-foreground rounded-full hover:bg-muted/10 transition-colors cursor-pointer"
+            >
+              <ArrowLeft className="w-5 h-5" />
+            </button>
+            <div>
+              <h2 className="text-lg font-bold">Struk Diunggah</h2>
+              {images.length > 1 && (
+                <p className="text-[10px] text-muted-foreground font-semibold">
+                  Struk {currentIndex + 1} dari {images.length}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Zoomable Image Area */}
+        <div className="relative flex-1 bg-gray-950 overflow-hidden flex items-center justify-center">
+          <div
+            className={cn(
+              "w-full h-full flex items-center justify-center overflow-hidden select-none",
+              scale > 1 ? "cursor-grab active:cursor-grabbing" : "",
+            )}
+            onMouseDown={handleMouseDown}
+            onMouseMove={handleMouseMove}
+            onMouseUp={handleMouseUpOrLeave}
+            onMouseLeave={handleMouseUpOrLeave}
+            onTouchStart={handleTouchStart}
+            onTouchMove={handleTouchMove}
+            onTouchEnd={handleMouseUpOrLeave}
+          >
+            {brokenIndexes.has(currentIndex) ? (
+              <div className="flex flex-col items-center gap-2 text-white/70 px-6 text-center">
+                <ImageOff className="w-10 h-10" />
+                <p className="text-sm font-bold">Struk sudah dihapus</p>
+                <p className="text-xs text-white/50">
+                  Struk hanya tersimpan selama 7 hari sejak diunggah.
+                </p>
+              </div>
+            ) : (
+              <img
+                src={resolveImageUrl(activeImage.url)}
+                alt={`Struk ${currentIndex + 1}`}
+                className="max-w-full max-h-full object-contain pointer-events-none transition-transform duration-100 ease-out"
+                style={{
+                  transform: `translate(${position.x}px, ${position.y}px) scale(${scale})`,
+                  transformOrigin: "center center",
+                }}
+                onError={() =>
+                  setBrokenIndexes((prev) => new Set(prev).add(currentIndex))
+                }
+              />
+            )}
+          </div>
+
+          {images.length > 1 && (
+            <>
+              <button
+                onClick={handlePrev}
+                className="absolute left-3 w-10 h-10 rounded-full bg-black/40 hover:bg-black/60 text-white flex items-center justify-center backdrop-blur-md transition-colors cursor-pointer"
+                title="Sebelumnya"
+              >
+                <ChevronLeft className="w-6 h-6" />
+              </button>
+              <button
+                onClick={handleNext}
+                className="absolute right-3 w-10 h-10 rounded-full bg-black/40 hover:bg-black/60 text-white flex items-center justify-center backdrop-blur-md transition-colors cursor-pointer"
+                title="Selanjutnya"
+              >
+                <ChevronRight className="w-6 h-6" />
+              </button>
+            </>
+          )}
+        </div>
+
+        {/* Zoom Controls */}
+        <div className="flex items-center justify-between px-6 py-3.5 bg-background border-t border-primary/5 shrink-0 pb-safe">
+          <div className="flex items-center gap-1.5">
+            <Button
+              onClick={handleZoomOut}
+              disabled={scale <= 1}
+              variant="outline"
+              className="w-9 h-9 p-0 rounded-lg flex items-center justify-center"
+              title="Zoom Out"
+            >
+              <ZoomOut className="w-4 h-4" />
+            </Button>
+            <span className="text-[11px] font-bold text-muted-foreground min-w-[36px] text-center">
+              {Math.round(scale * 100)}%
+            </span>
+            <Button
+              onClick={handleZoomIn}
+              disabled={scale >= 4}
+              variant="outline"
+              className="w-9 h-9 p-0 rounded-lg flex items-center justify-center"
+              title="Zoom In"
+            >
+              <ZoomIn className="w-4 h-4" />
+            </Button>
+          </div>
+
+          {(scale > 1 || position.x !== 0 || position.y !== 0) && (
+            <Button
+              onClick={handleResetZoom}
+              variant="ghost"
+              className="text-xs font-bold text-primary hover:bg-primary/5 px-3 h-9 rounded-lg"
+            >
+              <Maximize2 className="w-3.5 h-3.5 mr-1.5" />
+              Reset Zoom
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+};

--- a/src/components/splitbill/chat/ChatRoom.tsx
+++ b/src/components/splitbill/chat/ChatRoom.tsx
@@ -212,7 +212,7 @@ export function ChatRoom() {
       const newExpenses = (result.items ?? []).map((item) => ({
         id: uuidv4(),
         item: item.name,
-        amount: item.price * (item.quantity || 1),
+        amount: item.price,
         who: [] as string[],
         paidBy: payerName,
       }));

--- a/src/components/splitbill/chat/ReceiptScanCard.tsx
+++ b/src/components/splitbill/chat/ReceiptScanCard.tsx
@@ -404,7 +404,7 @@ export function ReceiptScanCard({
                       </span>
                     </span>
                     <span className="font-bold shrink-0">
-                      {formatToIDR(item.price * (item.quantity || 1))}
+                      {formatToIDR(item.price)}
                     </span>
                   </div>
                 ))}

--- a/src/components/ui/LoadingModal.tsx
+++ b/src/components/ui/LoadingModal.tsx
@@ -89,7 +89,7 @@ export function LoadingModal({ isOpen, image }: LoadingModalProps) {
       <div className="relative max-w-md w-full flex flex-col items-center text-center gap-6 z-10">
 
         {/* Square Scan Frame — shows the uploaded receipt with a sweeping scan line */}
-        <div className="relative w-60 h-60 md:w-64 md:h-64 rounded-2xl overflow-hidden border border-primary/15 bg-slate-50 shadow-[0_12px_24px_rgba(0,0,0,0.08)]">
+        <div className="relative w-60 h-60 md:w-64 md:h-64 rounded-2xl overflow-hidden border border-primary/15 bg-slate-50">
           {image ? (
             <img
               src={image}

--- a/src/lib/api/split-bills.ts
+++ b/src/lib/api/split-bills.ts
@@ -66,6 +66,7 @@ export interface BackendSplitBillRecord {
   summary: BackendSummary;
   status: "locked" | "editable";
   last_step?: "STEP_1" | "STEP_2" | "STEP_3" | "FINALIZED" | null;
+  receiptImages?: BackendReceiptImage[];
   createdAt: string;
   updatedAt: string;
 }
@@ -84,6 +85,7 @@ export interface BackendDraft {
   paymentMethodIds: string[];
   paymentMethodSnapshots: any[];
   summary: BackendSummary | null;
+  receiptImages?: BackendReceiptImage[];
   createdAt: string;
   updatedAt: string;
 }
@@ -190,6 +192,7 @@ export const mapBackendToFrontend = (record: BackendSplitBillRecord) => {
       additionalExpenses: [],
       selectedPaymentMethodIds: [],
       paymentMethodSnapshots: [],
+      receiptImages: [],
     };
   }
   return {
@@ -232,6 +235,7 @@ export const mapBackendToFrontend = (record: BackendSplitBillRecord) => {
           phoneNumber: s?.phoneNumber || "",
         }))
       : [],
+    receiptImages: Array.isArray(record.receiptImages) ? record.receiptImages : [],
   };
 };
 
@@ -304,6 +308,48 @@ export interface FinalizeDraftResponse {
   success: boolean;
   record: BackendSplitBillRecord;
 }
+
+// ─── Receipt Image API ────────────────────────────────────────────────────────
+
+export interface ReceiptImagePayload {
+  mime_type: string;
+  base64Image: string;
+}
+
+export interface BackendReceiptImage {
+  id: string;
+  url: string;
+  mimeType: string;
+  size: number;
+  width: number | null;
+  height: number | null;
+  uploadedAt: string;
+}
+
+export interface UploadReceiptImagesResponse {
+  success: boolean;
+  images: BackendReceiptImage[];
+}
+
+/** Converts "data:image/jpeg;base64,...." strings into upload payloads. Silently
+ * skips anything that isn't a well-formed base64 data URL. */
+export const parseDataUrlImages = (dataUrls: string[]): ReceiptImagePayload[] =>
+  dataUrls.reduce<ReceiptImagePayload[]>((acc, dataUrl) => {
+    const match = dataUrl.match(/^data:(.+);base64,(.+)$/);
+    if (match) {
+      acc.push({ mime_type: match[1], base64Image: match[2] });
+    }
+    return acc;
+  }, []);
+
+export const receiptImageApi = {
+  /** Uploads one or more receipt photos and links them to the split bill record (draft or finalized). */
+  upload: (recordId: string, images: ReceiptImagePayload[]) =>
+    apiClient.request<UploadReceiptImagesResponse>(`/api/split-bills/${recordId}/images`, {
+      method: "POST",
+      body: JSON.stringify({ images }),
+    }),
+};
 
 export const draftApi = {
   /** Create a new draft (Step 1). Auth is optional — sends token if available. */

--- a/src/store/useSplitBillChatStore.ts
+++ b/src/store/useSplitBillChatStore.ts
@@ -172,11 +172,12 @@ export const useSplitBillChatStore = create<SplitBillChatState>()(
         set({
           additionalExpenses: expenses.map((e) => {
             const nameLower = e.name.toLowerCase();
-            const isDiscount = nameLower.includes("diskon") || nameLower.includes("discount");
-            if (isDiscount) {
-              return { ...e, amount: -Math.abs(e.amount), paidBy: "merchant" };
+            const isNamedDiscount = nameLower.includes("diskon") || nameLower.includes("discount");
+            const amount = isNamedDiscount ? -Math.abs(e.amount) : e.amount;
+            if (amount < 0) {
+              return { ...e, amount, paidBy: "merchant" };
             }
-            return e;
+            return { ...e, amount };
           }),
         }),
 
@@ -186,9 +187,9 @@ export const useSplitBillChatStore = create<SplitBillChatState>()(
             if (e.id === id) {
               const newFields = { ...e, ...update };
               const nameLower = newFields.name.toLowerCase();
-              const isDiscount = nameLower.includes("diskon") || nameLower.includes("discount");
-              const finalAmount = isDiscount ? -Math.abs(newFields.amount) : newFields.amount;
-              const finalPaidBy = isDiscount ? "merchant" : newFields.paidBy;
+              const isNamedDiscount = nameLower.includes("diskon") || nameLower.includes("discount");
+              const finalAmount = isNamedDiscount ? -Math.abs(newFields.amount) : newFields.amount;
+              const finalPaidBy = finalAmount < 0 ? "merchant" : newFields.paidBy;
               return { ...newFields, amount: finalAmount, paidBy: finalPaidBy };
             }
             return e;

--- a/src/store/useSplitBillStore.ts
+++ b/src/store/useSplitBillStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import type { BackendReceiptImage } from "@/lib/api/split-bills";
 
 export interface Expense {
   id: string;
@@ -41,6 +42,9 @@ interface SplitBillState {
   // Scanned receipt images for interactive preview
   scannedReceiptImages: string[];
 
+  // Receipt images already uploaded & linked to the current draft/record
+  uploadedReceiptImages: BackendReceiptImage[];
+
   // Actions
   setActivityName: (name: string) => void;
   setSelectedPaymentMethodIds: (ids: string[]) => void;
@@ -76,6 +80,8 @@ interface SplitBillState {
   clearPendingCapturedImage: () => void;
   addScannedReceiptImage: (image: string) => void;
   clearScannedReceiptImages: () => void;
+  addUploadedReceiptImages: (images: BackendReceiptImage[]) => void;
+  clearUploadedReceiptImages: () => void;
 }
 
 export const useSplitBillStore = create<SplitBillState>()(
@@ -93,6 +99,7 @@ export const useSplitBillStore = create<SplitBillState>()(
       sourceReceiptId: undefined,
       pendingCapturedImage: undefined,
       scannedReceiptImages: [],
+      uploadedReceiptImages: [],
 
       setActivityName: (activityName) => set({ activityName }),
       setSelectedPaymentMethodIds: (ids) =>
@@ -269,6 +276,7 @@ export const useSplitBillStore = create<SplitBillState>()(
           sourceReceiptId: undefined,
           pendingCapturedImage: undefined,
           scannedReceiptImages: [],
+          uploadedReceiptImages: [],
         }),
 
       setPendingCapturedImage: (image) =>
@@ -284,6 +292,14 @@ export const useSplitBillStore = create<SplitBillState>()(
 
       clearScannedReceiptImages: () =>
         set({ scannedReceiptImages: [] }),
+
+      addUploadedReceiptImages: (images) =>
+        set((state) => ({
+          uploadedReceiptImages: [...state.uploadedReceiptImages, ...images],
+        })),
+
+      clearUploadedReceiptImages: () =>
+        set({ uploadedReceiptImages: [] }),
     }),
     {
       name: "split-bill-storage",

--- a/src/store/useSplitBillStore.ts
+++ b/src/store/useSplitBillStore.ts
@@ -169,9 +169,9 @@ export const useSplitBillStore = create<SplitBillState>()(
       addAdditionalExpense: (expense) =>
         set((state) => {
           const nameLower = expense.name.toLowerCase();
-          const isDiscount = nameLower.includes("diskon") || nameLower.includes("discount");
-          const finalAmount = isDiscount ? -Math.abs(expense.amount) : expense.amount;
-          const finalPaidBy = isDiscount ? "merchant" : expense.paidBy;
+          const isNamedDiscount = nameLower.includes("diskon") || nameLower.includes("discount");
+          const finalAmount = isNamedDiscount ? -Math.abs(expense.amount) : expense.amount;
+          const finalPaidBy = finalAmount < 0 ? "merchant" : expense.paidBy;
           return {
             additionalExpenses: [
               ...state.additionalExpenses,
@@ -188,9 +188,9 @@ export const useSplitBillStore = create<SplitBillState>()(
             if (e.id === id) {
               const newFields = { ...e, ...updatedExpense };
               const nameLower = newFields.name.toLowerCase();
-              const isDiscount = nameLower.includes("diskon") || nameLower.includes("discount");
-              const finalAmount = isDiscount ? -Math.abs(newFields.amount) : newFields.amount;
-              const finalPaidBy = isDiscount ? "merchant" : newFields.paidBy;
+              const isNamedDiscount = nameLower.includes("diskon") || nameLower.includes("discount");
+              const finalAmount = isNamedDiscount ? -Math.abs(newFields.amount) : newFields.amount;
+              const finalPaidBy = finalAmount < 0 ? "merchant" : newFields.paidBy;
               return { ...newFields, amount: finalAmount, paidBy: finalPaidBy };
             }
             return e;
@@ -210,11 +210,12 @@ export const useSplitBillStore = create<SplitBillState>()(
         set({
           additionalExpenses: expenses.map((e) => {
             const nameLower = e.name.toLowerCase();
-            const isDiscount = nameLower.includes("diskon") || nameLower.includes("discount");
-            if (isDiscount) {
-              return { ...e, amount: -Math.abs(e.amount), paidBy: "merchant" };
+            const isNamedDiscount = nameLower.includes("diskon") || nameLower.includes("discount");
+            const amount = isNamedDiscount ? -Math.abs(e.amount) : e.amount;
+            if (amount < 0) {
+              return { ...e, amount, paidBy: "merchant" };
             }
-            return e;
+            return { ...e, amount };
           }),
         }),
 


### PR DESCRIPTION
## Summary

**Uploaded receipt images (this session)**
- New "Uploaded Struk" section in bill summary (step 4 wizard + history detail page): thumbnails, filename, relative upload time, fullscreen zoomable viewer
- Handles expired/deleted images gracefully (7-day retention) with disabled placeholder state
- Fixed receipt image URL resolution (backend paths are relative to its own origin) and record field name (`receiptImages`)
- Camera-capture shortcuts (sidebar/footer) now compress images client-side before upload, consistent with the main AI scan form

**Split bill / AI scan**
- Compress scan images client-side, live preview in loading modal
- Capture additional receipt charges (parkir, PB1, pembulatan)
- Fix merchant discount detection (by amount, not name) and payer-less discount distribution
- Fix receipt item price double-multiplied by quantity
- Redesign wizard stepper, summary cards, quick-assign section; handle deleted-draft recovery
- Success card after AI scan import; default activity name fallback

**Chat / Agent Billy**
- Payer Picker step, TaxMethodCard layout, friend picker simplification
- Flatten chat bubbles/action cards, gradient-border entry card

**Other**
- Searchable friend combobox with device-contacts picker
- SEO: canonical www domain across metadata/share links
- Perf: lazy-mount below-fold homepage sections, skip redundant Google session check
- UI token cleanup (rounded-sm radius, border defaults, LoadingIndicator)
