### PR TITLE
perf(homepage): fix Speed Index, loading-flash bug, and session overhead

### DIFF
--- a/src/app/all-feature/AllFeatureClientPage.tsx
+++ b/src/app/all-feature/AllFeatureClientPage.tsx
@@ -127,7 +127,7 @@ export const AllFeatureClientPage = () => {
 
         <main className="relative z-10 w-full flex-1 pb-20 pt-4 px-4 flex flex-col">
           {/* PWA Banner */}
-          <div className="w-full rounded-2xl overflow-hidden mb-4">
+          <div className="w-full rounded-md overflow-hidden mb-4">
             <Image
               src="/img/banner-all-feature.png"
               alt="Semua Fitur Banner"

--- a/src/app/blog/BlogListClient.tsx
+++ b/src/app/blog/BlogListClient.tsx
@@ -68,7 +68,7 @@ export default function BlogListClient() {
               <input
                 type="text"
                 placeholder="Cari artikel menarik..."
-                className="w-full bg-white border border-border/60 rounded-2xl py-3 pl-12 pr-4 text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all shadow-sm"
+                className="w-full bg-white border border-border/60 rounded-md py-3 pl-12 pr-4 text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all shadow-sm"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
               />
@@ -92,7 +92,7 @@ export default function BlogListClient() {
             ))}
           </div>
         ) : (
-          <div className="bg-white rounded-3xl p-12 text-center shadow-soft border border-border/50 mt-12">
+          <div className="bg-white rounded-md p-12 text-center shadow-soft border border-border/50 mt-12">
             <div className="w-20 h-20 bg-muted rounded-full flex items-center justify-center mx-auto mb-6">
               <Search className="w-10 h-10 text-muted-foreground/30" />
             </div>

--- a/src/app/blog/[slug]/BlogDetailClient.tsx
+++ b/src/app/blog/[slug]/BlogDetailClient.tsx
@@ -228,7 +228,7 @@ export default function BlogDetailClient({
         {/* Right Column: Sidebar */}
         <aside className="w-full lg:w-[360px] shrink-0 flex flex-col gap-6">
           {/* Ads Banner CTA to /split-bill */}
-          <div className="w-full bg-gradient-to-br from-slate-50 to-slate-100/50 p-6 rounded-2xl flex flex-col gap-4 relative overflow-hidden">
+          <div className="w-full bg-gradient-to-br from-slate-50 to-slate-100/50 p-6 rounded-md flex flex-col gap-4 relative overflow-hidden">
             <div className="space-y-2">
               <div className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-primary/10 text-primary text-[10px] font-bold uppercase tracking-wider">
                 Fitur Populer
@@ -249,7 +249,7 @@ export default function BlogDetailClient({
 
           {/* Sidebar: Read Next Section */}
           {recentBlogs.length > 0 && (
-            <div className="w-full bg-gray-50/50 lg:bg-transparent lg:p-0 rounded-3xl">
+            <div className="w-full bg-gray-50/50 lg:bg-transparent lg:p-0 rounded-md">
               <h2 className="text-xl font-black mb-6 tracking-tight text-foreground">
                 Baca Artikel Lainnya
               </h2>

--- a/src/app/collect-money/CollectMoneyClientPage.tsx
+++ b/src/app/collect-money/CollectMoneyClientPage.tsx
@@ -187,7 +187,7 @@ function CollectMoneyContent() {
                   </h3>
 
                   {displayedCollections.length === 0 ? (
-                    <div className="flex flex-col items-center justify-center py-12 px-4 text-center border-2 border-dashed border-muted/40 rounded-2xl bg-muted/5">
+                    <div className="flex flex-col items-center justify-center py-12 px-4 text-center border-2 border-dashed border-muted/40 rounded-md bg-muted/5">
                       <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mb-4 text-primary">
                         <Wallet className="w-8 h-8" />
                       </div>

--- a/src/app/donate/DonateClientPage.tsx
+++ b/src/app/donate/DonateClientPage.tsx
@@ -99,7 +99,7 @@ export default function DonateClientPage() {
         <main className="relative z-10 w-full pb-10">
           <div className="px-4 pt-4 space-y-6">
             {/* Welcome Card */}
-            <Card className="p-6 border border-border/50 shadow-md rounded-2xl bg-card relative overflow-hidden">
+            <Card className="p-6 border border-border/50 shadow-md rounded-md bg-card relative overflow-hidden">
               <div className="absolute top-0 right-0 p-2 opacity-[0.03] rotate-12">
                 <Coffee className="w-24 h-24" />
               </div>
@@ -135,7 +135,7 @@ export default function DonateClientPage() {
             </Card>
 
             {/* Cost Tracker Card */}
-            <Card className="p-5 border border-border/50 shadow-sm rounded-2xl bg-card">
+            <Card className="p-5 border border-border/50 shadow-sm rounded-md bg-card">
               <div className="flex items-center justify-between mb-3">
                 <div className="space-y-0.5">
                   <h3 className="text-xs font-bold text-foreground flex items-center gap-1.5 uppercase tracking-wider">
@@ -177,7 +177,7 @@ export default function DonateClientPage() {
                     <button
                       key={tier.id}
                       onClick={() => setSelectedTier(tier.id)}
-                      className={`text-left p-4 rounded-2xl border transition-all duration-300 relative overflow-hidden flex flex-col justify-between cursor-pointer ${isSelected
+                      className={`text-left p-4 rounded-md border transition-all duration-300 relative overflow-hidden flex flex-col justify-between cursor-pointer ${isSelected
                         ? "border-primary bg-primary/[0.03] shadow-sm ring-1 ring-primary"
                         : "border-border/60 bg-card hover:border-border-hover"
                         }`}
@@ -211,7 +211,7 @@ export default function DonateClientPage() {
                 <Sparkles className="w-3.5 h-3.5 fill-primary" /> Metode Donasi Utama
               </h3>
 
-              <Card className="py-4 border-2 border-primary bg-card shadow-soft rounded-2xl flex flex-col items-center text-center relative overflow-hidden">
+              <Card className="py-4 border-2 border-primary bg-card shadow-soft rounded-md flex flex-col items-center text-center relative overflow-hidden">
                 {/* DANA Header */}
                 <div className="flex items-center gap-2">
                   <div className="h-6 w-16 flex items-center justify-center">
@@ -269,7 +269,7 @@ export default function DonateClientPage() {
 
               <div className="space-y-3">
                 {/* Saweria Card */}
-                <Card className="p-4 border border-border/50 hover:border-primary/20 transition-all rounded-2xl bg-card flex items-center justify-between gap-4">
+                <Card className="p-4 border border-border/50 hover:border-primary/20 transition-all rounded-md bg-card flex items-center justify-between gap-4">
                   <div className="flex items-center gap-3">
                     <div className="h-6 w-10 flex items-center justify-center shrink-0 relative">
                       <Image
@@ -305,7 +305,7 @@ export default function DonateClientPage() {
               </h3>
               <div
                 onClick={() => (window.location.href = "/review")}
-                className="relative rounded-2xl p-5 text-white active:scale-[0.98] transition-all group cursor-pointer bg-brand-reversed"
+                className="relative rounded-md p-5 text-white active:scale-[0.98] transition-all group cursor-pointer bg-brand-reversed"
               >
                 <div className="absolute bottom-0 right-2 w-28 h-32 transition-transform group-hover:scale-110 group-hover:rotate-3 z-20">
                   <img
@@ -331,7 +331,7 @@ export default function DonateClientPage() {
 
       {/* Hidden Ticket for Download */}
       <div className="fixed top-[-9999px] left-[-9999px]">
-        <Card id="qris-ticket-hidden-donate" className="p-6 bg-white rounded-2xl border-2 border-primary w-[360px] shadow-none relative overflow-hidden flex flex-col items-center text-center">
+        <Card id="qris-ticket-hidden-donate" className="p-6 bg-white rounded-md border-2 border-primary w-[360px] shadow-none relative overflow-hidden flex flex-col items-center text-center">
           <div className="flex flex-col items-center w-full">
             {/* DANA Header */}
             <div className="flex items-center gap-2 mb-4">

--- a/src/app/faq/FAQClientPage.tsx
+++ b/src/app/faq/FAQClientPage.tsx
@@ -77,7 +77,7 @@ export default function FAQClientPage() {
               <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground/50 z-10" />
               <Input
                 placeholder="Cari pertanyaan..."
-                className="pl-11 h-14 bg-white border-primary/10 shadow-soft focus:ring-primary/20 rounded-2xl text-sm"
+                className="pl-11 h-14 bg-white border-primary/10 shadow-soft focus:ring-primary/20 rounded-md text-sm"
                 value={searchQuery}
                 onChange={handleSearchChange}
               />
@@ -187,9 +187,9 @@ export default function FAQClientPage() {
         </div>
 
         {/* Contact Section */}
-        <div className="p-6 bg-primary/[0.03] border border-primary/10 rounded-3xl space-y-4">
+        <div className="p-6 bg-primary/[0.03] border border-primary/10 rounded-md space-y-4">
           <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-2xl bg-primary/10 flex items-center justify-center">
+            <div className="w-10 h-10 rounded-md bg-primary/10 flex items-center justify-center">
               <HelpCircle className="w-5 h-5 text-primary" />
             </div>
             <div>
@@ -207,7 +207,7 @@ export default function FAQClientPage() {
             rel="noopener noreferrer"
             className="block w-full"
           >
-            <button className="w-full h-12 bg-white border border-primary/20 text-primary font-bold text-sm rounded-2xl flex items-center justify-center gap-2 hover:bg-primary/5 transition-all cursor-pointer">
+            <button className="w-full h-12 bg-white border border-primary/20 text-primary font-bold text-sm rounded-md flex items-center justify-center gap-2 hover:bg-primary/5 transition-all cursor-pointer">
               Hubungi Support <ArrowRight className="w-3.5 h-3.5" />
             </button>
           </a>

--- a/src/app/history/invoice/[id]/page.tsx
+++ b/src/app/history/invoice/[id]/page.tsx
@@ -71,7 +71,7 @@ export default function InvoiceDetailPage() {
 
         <main className="flex-1 p-4 pb-10 space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-700">
           {/* Main Info Card */}
-          <Card className="border-none shadow-soft overflow-hidden rounded-3xl">
+          <Card className="border-none shadow-soft overflow-hidden rounded-md">
             <CardContent className="p-0">
               <div className="bg-[#f0f4ff] p-8 text-foreground text-center relative overflow-hidden">
                 {/* Decorative background element */}
@@ -80,7 +80,7 @@ export default function InvoiceDetailPage() {
 
                 <div className="relative z-10 space-y-4">
                   <div className="flex flex-col items-center gap-1">
-                    <div className="w-12 h-12 bg-white rounded-2xl flex items-center justify-center mb-2 shadow-sm border border-primary/10">
+                    <div className="w-12 h-12 bg-white rounded-md flex items-center justify-center mb-2 shadow-sm border border-primary/10">
                       <FileText className="w-6 h-6 text-primary" />
                     </div>
                     <h2 className="text-md font-black tracking-tight text-foreground/80 uppercase">
@@ -319,7 +319,7 @@ export default function InvoiceDetailPage() {
           <Button
             onClick={handleDownloadPDF}
             disabled={isDownloading}
-            className="w-full h-14 font-black rounded-2xl shadow-xl shadow-primary/20 bg-primary hover:bg-primary/90 text-white transition-all text-base tracking-tight active:scale-[0.98]"
+            className="w-full h-14 font-black rounded-md shadow-xl shadow-primary/20 bg-primary hover:bg-primary/90 text-white transition-all text-base tracking-tight active:scale-[0.98]"
           >
             <Download className="w-5 h-5 mr-3" />
             {isDownloading ? "Downloading..." : "Download Invoice (PDF)"}

--- a/src/app/history/split-bill/[id]/page.tsx
+++ b/src/app/history/split-bill/[id]/page.tsx
@@ -253,7 +253,7 @@ function SplitBillDetailView({
                   trackSplitBill.reEntry();
                   router.push("/split-bill");
                 }}
-                className="relative rounded-2xl p-5 text-white active:scale-[0.98] transition-all group cursor-pointer bg-brand-reversed"
+                className="relative rounded-md p-5 text-white active:scale-[0.98] transition-all group cursor-pointer bg-brand-reversed"
               >
                 <div className="absolute -top-1 right-4 p-1 opacity-100 transition-transform group-hover:scale-110 group-hover:rotate-6 z-20">
                   <img

--- a/src/app/invoice/components/BilledToShortcut.tsx
+++ b/src/app/invoice/components/BilledToShortcut.tsx
@@ -46,7 +46,7 @@ export const BilledToShortcut = () => {
                   setCurrentStep(2);
                   router.push("/invoice/create?step=2");
                 }}
-                className="w-[100px] h-[100px] rounded-2xl border-2 border-dashed border-primary/20 bg-white/50 hover:bg-primary/5 flex flex-col items-center justify-center gap-2 transition-all active:scale-95 group"
+                className="w-[100px] h-[100px] rounded-md border-2 border-dashed border-primary/20 bg-white/50 hover:bg-primary/5 flex flex-col items-center justify-center gap-2 transition-all active:scale-95 group"
               >
                 <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center group-hover:bg-primary group-hover:text-white transition-colors">
                   <Plus className="w-5 h-5 text-primary group-hover:text-white" />

--- a/src/app/invoice/components/Step1Details.tsx
+++ b/src/app/invoice/components/Step1Details.tsx
@@ -107,9 +107,9 @@ export function Step1Details() {
               onChange={(e) => updateInvoice({ dueDate: e.target.value })}
               className={
                 !currentInvoice.dueDate ||
-                (currentInvoice.invoiceDate &&
-                  currentInvoice.dueDate &&
-                  new Date(currentInvoice.dueDate) <
+                  (currentInvoice.invoiceDate &&
+                    currentInvoice.dueDate &&
+                    new Date(currentInvoice.dueDate) <
                     new Date(currentInvoice.invoiceDate))
                   ? "border-destructive/30"
                   : ""
@@ -119,7 +119,7 @@ export function Step1Details() {
               <FormError message="Jatuh tempo harus diisi" />
             ) : currentInvoice.invoiceDate &&
               new Date(currentInvoice.dueDate) <
-                new Date(currentInvoice.invoiceDate) ? (
+              new Date(currentInvoice.invoiceDate) ? (
               <FormError message="Jatuh tempo tidak boleh sebelum tanggal invoice" />
             ) : null}
           </div>
@@ -134,7 +134,7 @@ export function Step1Details() {
           {!logoPreview ? (
             <div
               onClick={() => fileInputRef.current?.click()}
-              className="border-2 border-dashed border-primary/20 rounded-2xl py-4 flex flex-col items-center justify-center gap-3 bg-primary/5 hover:bg-primary/10 transition-colors cursor-pointer group"
+              className="border-2 border-dashed border-primary/20 rounded-md py-4 flex flex-col items-center justify-center gap-3 bg-primary/5 hover:bg-primary/10 transition-colors cursor-pointer group"
             >
               <div className="w-12 h-12 rounded-full bg-white shadow-soft flex items-center justify-center text-primary group-hover:scale-110 transition-transform">
                 <Camera className="w-6 h-6" />
@@ -154,7 +154,7 @@ export function Step1Details() {
               />
             </div>
           ) : (
-            <div className="relative aspect-[2/0.63] rounded-2xl overflow-hidden border border-primary/20 bg-muted">
+            <div className="relative aspect-[2/0.63] rounded-md overflow-hidden border border-primary/20 bg-muted">
               <Image
                 src={logoPreview}
                 alt="Logo preview"

--- a/src/app/invoice/components/Step3Items.tsx
+++ b/src/app/invoice/components/Step3Items.tsx
@@ -153,7 +153,7 @@ export function Step3Items() {
               />
               <FormError message={fieldErrors.rate} />
             </div>
-            <div className="flex items-center px-4 py-1 rounded-2xl border border-primary/10 bg-white text-sm font-bold text-foreground h-12 mt-0">
+            <div className="flex items-center px-4 py-1 rounded-md border border-primary/10 bg-white text-sm font-bold text-foreground h-12 mt-0">
               {formatToIDR(newItem.qty * newItem.rate)}
             </div>
           </div>
@@ -222,7 +222,7 @@ export function Step3Items() {
                     });
                     calculateTotals();
                   }}
-                  className="h-12 w-full rounded-2xl border border-primary/10 bg-white px-4 py-1 pr-8 text-sm font-medium transition-all focus:outline-none focus:border-primary/30 focus:ring-2 focus:ring-primary/10 appearance-none cursor-pointer"
+                  className="h-12 w-full rounded-md border border-primary/10 bg-white px-4 py-1 pr-8 text-sm font-medium transition-all focus:outline-none focus:border-primary/30 focus:ring-2 focus:ring-primary/10 appearance-none cursor-pointer"
                 >
                   <option value="amount">Fixed (Rp)</option>
                   <option value="percent">Percentage (%)</option>

--- a/src/app/invoice/create/page.tsx
+++ b/src/app/invoice/create/page.tsx
@@ -204,7 +204,7 @@ function InvoiceCreateContent() {
                 onClick={handleNext}
                 disabled={!canProceed()}
                 className={cn(
-                  "w-full h-14 text-lg font-bold rounded-2xl shadow-xl shadow-primary/20 text-white !disabled:opacity-100 disabled:bg-[#ede9fe] disabled:text-primary/40 disabled:shadow-none transition-all duration-300",
+                  "w-full h-14 text-lg font-bold rounded-md shadow-xl shadow-primary/20 text-white !disabled:opacity-100 disabled:bg-[#ede9fe] disabled:text-primary/40 disabled:shadow-none transition-all duration-300",
                   currentStep === 6
                     ? "bg-green-600 hover:bg-green-700 shadow-green-600/20"
                     : "bg-primary hover:bg-primary/90",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -100,7 +100,6 @@ export const metadata: Metadata = {
 };
 
 import { ResponsiveShell } from "@/components/layout/ResponsiveShell";
-import { SessionProvider } from "next-auth/react";
 
 export default function RootLayout({
   children,
@@ -144,11 +143,9 @@ export default function RootLayout({
         {GA_ID && <GoogleAnalytics gaId={GA_ID} />}
         <AppEntryTracker />
         <ThemeProvider>
-          <SessionProvider basePath="/api/auth">
-            <ResponsiveShell>
-              {children}
-            </ResponsiveShell>
-          </SessionProvider>
+          <ResponsiveShell>
+            {children}
+          </ResponsiveShell>
         </ThemeProvider>
         <Toaster
           richColors

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -187,7 +187,7 @@ function LoginPageContent() {
             </div>
 
             {/* Social Proof Card — overlaps transparent bottom of PNG */}
-            <div className="relative z-10 flex items-center gap-3 bg-white/75 backdrop-blur-md border border-white p-3 rounded-2xl max-w-[380px] w-[90%] shadow-sm mx-auto -mt-1">
+            <div className="relative z-10 flex items-center gap-3 bg-white/75 backdrop-blur-md border border-white p-3 rounded-md max-w-[380px] w-[90%] shadow-sm mx-auto -mt-1">
               <div className="flex items-center">
                 {avatarSeeds.map((seed, idx) => (
                   <div
@@ -284,7 +284,7 @@ function LoginPageContent() {
             transition={{ duration: 0.5, delay: 0.1 }}
             className="relative z-10 md:mt-0 -mt-28 sm:-mt-34"
           >
-            <Card className="rounded-2xl border border-white/60 bg-white p-5 sm:p-7 shadow-[0_8px_30px_rgba(0,0,0,0.05)]">
+            <Card className="rounded-md border border-white/60 bg-white p-5 sm:p-7 shadow-[0_8px_30px_rgba(0,0,0,0.05)]">
               <CardHeader className="sr-only">
                 <h2 className="text-xl font-bold">Masuk</h2>
               </CardHeader>
@@ -309,7 +309,7 @@ function LoginPageContent() {
                   <motion.div
                     initial={{ opacity: 0, scale: 0.95 }}
                     animate={{ opacity: 1, scale: 1 }}
-                    className="mt-4 p-4 bg-primary/5 rounded-2xl border border-primary/10 text-center space-y-2"
+                    className="mt-4 p-4 bg-primary/5 rounded-md border border-primary/10 text-center space-y-2"
                   >
                     <p className="text-sm text-foreground">
                       Email kamu belum diverifikasi. Cek folder Inbox atau Spam kamu.
@@ -341,7 +341,7 @@ function LoginPageContent() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 0.3 }}
-            className="flex md:hidden items-center gap-3.5 bg-white border border-slate-100/60 p-3.5 rounded-2xl shadow-[0_4px_12px_rgba(0,0,0,0.01)]"
+            className="flex md:hidden items-center gap-3.5 bg-white border border-slate-100/60 p-3.5 rounded-md shadow-[0_4px_12px_rgba(0,0,0,0.01)]"
           >
             <div className="flex items-center">
               {avatarSeeds.map((seed, idx) => (

--- a/src/app/membership/MembershipClientPage.tsx
+++ b/src/app/membership/MembershipClientPage.tsx
@@ -68,11 +68,11 @@ export default function MembershipClientPage() {
 
           <main className="relative z-10 w-full px-4 pt-4 pb-4">
             <div className="space-y-4">
-              <div className="rounded-2xl border border-border/50 bg-white p-6 animate-pulse">
+              <div className="rounded-md border border-border/50 bg-white p-6 animate-pulse">
                 <div className="flex flex-col items-center space-y-6">
                   {/* VIP Icon */}
                   <div className="w-20 h-20 rounded-full bg-muted" />
-                  
+
                   {/* Text */}
                   <div className="space-y-3 w-full flex flex-col items-center">
                     <div className="h-8 w-48 bg-muted rounded-md" />
@@ -81,17 +81,17 @@ export default function MembershipClientPage() {
                   </div>
 
                   {/* Table */}
-                  <div className="w-full h-[260px] bg-muted rounded-2xl" />
+                  <div className="w-full h-[260px] bg-muted rounded-md" />
 
                   {/* Button */}
-                  <div className="w-full h-14 bg-muted rounded-2xl" />
+                  <div className="w-full h-14 bg-muted rounded-md" />
                 </div>
               </div>
 
               {/* Secondary Card */}
-              <div className="rounded-2xl border border-border/50 bg-white p-5 animate-pulse">
+              <div className="rounded-md border border-border/50 bg-white p-5 animate-pulse">
                 <div className="flex items-start gap-4">
-                  <div className="w-12 h-12 rounded-2xl bg-muted shrink-0" />
+                  <div className="w-12 h-12 rounded-md bg-muted shrink-0" />
                   <div className="space-y-2 flex-1 pt-1">
                     <div className="h-4 w-48 bg-muted rounded-md" />
                     <div className="h-3 w-full bg-muted rounded-md" />
@@ -131,7 +131,7 @@ export default function MembershipClientPage() {
                   </p>
                 </div>
 
-                <div className="border border-primary rounded-2xl bg-white overflow-hidden shadow-sm">
+                <div className="border border-primary rounded-md bg-white overflow-hidden shadow-sm">
                   <div className="grid grid-cols-[1.2fr_1fr_1fr] gap-0 bg-primary/5 border-b border-primary">
                     <span className="p-3.5 text-center text-[11px] font-black uppercase tracking-widest text-muted-foreground border-r border-primary/20">
                       Fitur
@@ -210,7 +210,7 @@ export default function MembershipClientPage() {
 
                   {/* Bordered Comparison Table - Larger Text & Primary Borders */}
                   <div className="w-full pt-4 mb-2">
-                    <div className="border border-primary rounded-2xl bg-white overflow-hidden">
+                    <div className="border border-primary rounded-md bg-white overflow-hidden">
                       <div className="grid grid-cols-[1.2fr_1fr_1fr] gap-0 bg-primary/5 border-b border-primary">
                         <span className="p-3.5 text-center text-[11px] font-black uppercase tracking-widest text-muted-foreground border-r border-primary/20">
                           Fitur
@@ -278,7 +278,7 @@ export default function MembershipClientPage() {
                   </div>
 
                   <Button
-                    className="w-full h-14 rounded-2xl bg-primary text-white hover:bg-primary/90 text-base font-black transition-all active:scale-[0.98] mt-4"
+                    className="w-full h-14 rounded-md bg-primary text-white hover:bg-primary/90 text-base font-black transition-all active:scale-[0.98] mt-4"
                     onClick={() => router.push("/subscription")}
                   >
                     Lihat Paket Langganan
@@ -289,7 +289,7 @@ export default function MembershipClientPage() {
               {/* Secondary Info */}
               <Card className="p-5 border-none shadow-soft bg-white/50 backdrop-blur-sm">
                 <div className="flex items-top gap-4">
-                  <div className="w-12 h-12 rounded-2xl bg-amber-100 flex items-center justify-center text-amber-600 shrink-0">
+                  <div className="w-12 h-12 rounded-md bg-amber-100 flex items-center justify-center text-amber-600 shrink-0">
                     <Zap className="w-6 h-6" />
                   </div>
                   <div>

--- a/src/app/profile/orders/[id]/page.tsx
+++ b/src/app/profile/orders/[id]/page.tsx
@@ -158,7 +158,7 @@ export default function OrderDetailPage() {
             <h3 className="text-xs font-bold text-muted-foreground uppercase tracking-widest px-1">
               Informasi Pesanan
             </h3>
-            <Card className="border-border/50 shadow-sm rounded-2xl overflow-hidden">
+            <Card className="border-border/50 shadow-sm rounded-md overflow-hidden">
               <CardContent className="p-0 divide-y divide-border/50">
                 <div className="p-4 flex items-center justify-between">
                   <div className="flex items-center gap-3">
@@ -212,7 +212,7 @@ export default function OrderDetailPage() {
               <h3 className="text-xs font-bold text-muted-foreground uppercase tracking-widest px-1">
                 Rincian Paket
               </h3>
-              <Card className="border-border/50 shadow-sm rounded-2xl overflow-hidden">
+              <Card className="border-border/50 shadow-sm rounded-md overflow-hidden">
                 <CardContent className="p-5 space-y-4">
                   <div className="flex items-start justify-between">
                     <div className="flex items-center gap-3">
@@ -260,7 +260,7 @@ export default function OrderDetailPage() {
             <h3 className="text-xs font-bold text-muted-foreground uppercase tracking-widest px-1">
               Rincian Harga
             </h3>
-            <Card className="border-border/50 shadow-sm rounded-2xl overflow-hidden">
+            <Card className="border-border/50 shadow-sm rounded-md overflow-hidden">
               <CardContent className="p-0 divide-y divide-border/50">
                 <div className="p-4 flex items-center justify-between text-sm">
                   <span className="text-muted-foreground font-medium">
@@ -298,7 +298,7 @@ export default function OrderDetailPage() {
               <h3 className="text-xs font-bold text-muted-foreground uppercase tracking-widest px-1">
                 Detail Pembayaran
               </h3>
-              <Card className="border-border/50 shadow-sm rounded-2xl overflow-hidden bg-white">
+              <Card className="border-border/50 shadow-sm rounded-md overflow-hidden bg-white">
                 <CardContent className="p-5 flex items-center justify-between">
                   <div className="flex items-center gap-3">
                     <div className="w-10 h-10 rounded-xl bg-green-500/10 flex items-center justify-center">

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -297,7 +297,7 @@ export default function ProfilePage() {
                     <div className="snap-center shrink-0">
                       <Card
                         onClick={() => router.push("/wallet")}
-                        className="relative w-[42vw] sm:w-[220px] shrink-0 aspect-[1.4/1] rounded-2xl border border-slate-200 bg-white hover:border-slate-300 flex flex-col items-center justify-center gap-2 text-slate-600 hover:text-primary transition-all active:scale-95 cursor-pointer shadow-none"
+                        className="relative w-[42vw] sm:w-[220px] shrink-0 aspect-[1.4/1] rounded-md border border-slate-200 bg-white hover:border-slate-300 flex flex-col items-center justify-center gap-2 text-slate-600 hover:text-primary transition-all active:scale-95 cursor-pointer shadow-none"
                       >
                         <div className="w-10 h-10 rounded-full bg-primary/5 flex items-center justify-center text-primary">
                           <Wallet className="w-5 h-5" />

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -125,7 +125,7 @@ function RegisterPageContent() {
             </div>
 
             {/* Social Proof Card — overlaps transparent bottom of PNG */}
-            <div className="relative z-10 flex items-center gap-3 bg-white/75 backdrop-blur-md border border-white p-3 rounded-2xl max-w-[380px] w-[90%] shadow-sm mx-auto -mt-1">
+            <div className="relative z-10 flex items-center gap-3 bg-white/75 backdrop-blur-md border border-white p-3 rounded-md max-w-[380px] w-[90%] shadow-sm mx-auto -mt-1">
               <div className="flex items-center">
                 {avatarSeeds.map((seed, idx) => (
                   <div
@@ -221,7 +221,7 @@ function RegisterPageContent() {
             transition={{ duration: 0.5, delay: 0.1 }}
             className="relative z-10 md:mt-0 -mt-28 sm:-mt-34"
           >
-            <Card className="rounded-2xl border border-white/60 bg-white p-5 sm:p-7 shadow-[0_8px_30px_rgba(0,0,0,0.05)]">
+            <Card className="rounded-md border border-white/60 bg-white p-5 sm:p-7 shadow-[0_8px_30px_rgba(0,0,0,0.05)]">
               <CardHeader className="sr-only">
                 <h2 className="text-xl font-bold">Daftar</h2>
               </CardHeader>
@@ -250,7 +250,7 @@ function RegisterPageContent() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 0.3 }}
-            className="flex md:hidden items-center gap-3.5 bg-white border border-slate-100/60 p-3.5 rounded-2xl shadow-[0_4px_12px_rgba(0,0,0,0.01)]"
+            className="flex md:hidden items-center gap-3.5 bg-white border border-slate-100/60 p-3.5 rounded-md shadow-[0_4px_12px_rgba(0,0,0,0.01)]"
           >
             <div className="flex items-center">
               {avatarSeeds.map((seed, idx) => (

--- a/src/app/split-later/SplitLaterClientPage.tsx
+++ b/src/app/split-later/SplitLaterClientPage.tsx
@@ -491,7 +491,7 @@ export default function SplitLaterClientPage() {
                     }
                     router.replace("/split-later?step=2");
                   }}
-                  className="w-full h-14 text-lg font-bold rounded-2xl shadow-xl transition-all duration-300 active:scale-95 bg-primary text-white shadow-primary/20"
+                  className="w-full h-14 text-lg font-bold rounded-md shadow-xl transition-all duration-300 active:scale-95 bg-primary text-white shadow-primary/20"
                 >
                   Lanjut Isi Detail Acara
                 </Button>
@@ -502,7 +502,7 @@ export default function SplitLaterClientPage() {
                   <button
                     type="button"
                     onClick={() => router.replace("/split-later?step=1")}
-                    className="flex-1 h-14 rounded-2xl bg-white border border-primary/20 text-primary text-base font-bold active:scale-95 transition-all cursor-pointer"
+                    className="flex-1 h-14 rounded-md bg-white border border-primary/20 text-primary text-base font-bold active:scale-95 transition-all cursor-pointer"
                   >
                     Kembali
                   </button>
@@ -515,7 +515,7 @@ export default function SplitLaterClientPage() {
                       }
                       router.replace("/split-later?step=3");
                     }}
-                    className="flex-1 h-14 text-base font-bold rounded-2xl shadow-xl shadow-primary/20"
+                    className="flex-1 h-14 text-base font-bold rounded-md shadow-xl shadow-primary/20"
                   >
                     Lanjut Tambah Peserta
                   </Button>
@@ -527,7 +527,7 @@ export default function SplitLaterClientPage() {
                   <button
                     type="button"
                     onClick={() => router.replace("/split-later?step=2")}
-                    className="flex-1 h-14 rounded-2xl bg-white border border-primary/20 text-primary text-base font-bold active:scale-95 transition-all cursor-pointer"
+                    className="flex-1 h-14 rounded-md bg-white border border-primary/20 text-primary text-base font-bold active:scale-95 transition-all cursor-pointer"
                   >
                     Kembali
                   </button>
@@ -542,7 +542,7 @@ export default function SplitLaterClientPage() {
                     }}
                     disabled={participants.length < 2}
                     className={cn(
-                      "flex-1 h-14 text-base font-bold rounded-2xl shadow-xl transition-all duration-300",
+                      "flex-1 h-14 text-base font-bold rounded-md shadow-xl transition-all duration-300",
                       participants.length >= 2
                         ? "bg-primary text-white shadow-primary/20"
                         : "bg-primary/10 text-primary shadow-none opacity-80",
@@ -559,7 +559,7 @@ export default function SplitLaterClientPage() {
                     type="button"
                     disabled={isUploading}
                     onClick={() => handleSave(true)}
-                    className="flex-1 h-14 rounded-2xl bg-white border border-primary/20 text-primary text-base font-bold active:scale-95 transition-all hover:bg-muted/10 cursor-pointer disabled:opacity-50"
+                    className="flex-1 h-14 rounded-md bg-white border border-primary/20 text-primary text-base font-bold active:scale-95 transition-all hover:bg-muted/10 cursor-pointer disabled:opacity-50"
                   >
                     Lewati Dulu
                   </button>
@@ -567,7 +567,7 @@ export default function SplitLaterClientPage() {
                     type="button"
                     disabled={!receiptFile || isUploading}
                     onClick={() => handleSave(false)}
-                    className="flex-1 h-14 text-base font-bold rounded-2xl shadow-xl shadow-primary/20"
+                    className="flex-1 h-14 text-base font-bold rounded-md shadow-xl shadow-primary/20"
                   >
                     {isUploading ? (
                       <span className="flex items-center gap-1 justify-center">
@@ -633,7 +633,7 @@ export default function SplitLaterClientPage() {
               action={
                 <Button
                   onClick={() => router.push("/split-later?step=1")}
-                  className="h-12 px-8 font-bold rounded-2xl"
+                  className="h-12 px-8 font-bold rounded-md"
                 >
                   <Plus className="w-4 h-4 mr-2" />
                   Buat Split Later Pertama

--- a/src/app/split-later/[bucketId]/BucketDetailClientPage.tsx
+++ b/src/app/split-later/[bucketId]/BucketDetailClientPage.tsx
@@ -230,7 +230,7 @@ export default function BucketDetailClientPage({
 
           {/* Hero stats Card - White card below blue BG */}
           <div className="px-4 -mt-2 mb-4">
-            <div className="rounded-2xl backdrop-blur-xs text-card-foreground border-none shadow-md shadow-primary/5 bg-white relative overflow-hidden p-4">
+            <div className="rounded-md backdrop-blur-xs text-card-foreground border-none shadow-md shadow-primary/5 bg-white relative overflow-hidden p-4">
               <p className="text-[10px] font-black text-foreground/50 mb-3 px-1 tracking-wider uppercase">
                 Status Split Later
               </p>

--- a/src/app/subscription/payment/[orderId]/page.tsx
+++ b/src/app/subscription/payment/[orderId]/page.tsx
@@ -360,7 +360,7 @@ export default function PaymentPage() {
 
           {/* QRIS Section */}
           <div className="flex flex-col items-center space-y-6">
-            <Card className="p-6 bg-white rounded-2xl border-none shadow-soft">
+            <Card className="p-6 bg-white rounded-md border-none shadow-soft">
               <div className="flex flex-col items-center gap-4">
                 <div className="relative bg-white">
                   {order.qrisData?.payment_number ? (
@@ -530,7 +530,7 @@ export default function PaymentPage() {
           </div>
 
           {/* Trust Badge */}
-          <div className="flex items-center gap-4 p-4 bg-white rounded-2xl border border-border/50">
+          <div className="flex items-center gap-4 p-4 bg-white rounded-md border border-border/50">
             <div className="shrink-0 w-12 h-12 relative">
               <Image
                 src="/img/icon-privacy.png"

--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -98,7 +98,7 @@ export function AuthModal({
           <Link
             href={loginUrl}
             onClick={onClose}
-            className="w-full h-14 border border-dashed border-primary/20 hover:border-primary/40 text-primary transition-colors rounded-2xl flex items-center justify-center gap-3 font-bold cursor-pointer"
+            className="w-full h-14 border border-dashed border-primary/20 hover:border-primary/40 text-primary transition-colors rounded-md flex items-center justify-center gap-3 font-bold cursor-pointer"
           >
             <Mail className="w-5 h-5" />
             <span>Masuk dengan Email</span>

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -60,7 +60,7 @@ export function LoginForm({
         <motion.div
           initial={{ opacity: 0, x: -10 }}
           animate={{ opacity: 1, x: 0 }}
-          className="bg-destructive/10 border border-destructive/20 rounded-2xl p-4 flex items-center gap-3"
+          className="bg-destructive/10 border border-destructive/20 rounded-md p-4 flex items-center gap-3"
         >
           <div className="w-5 h-5 rounded-full bg-destructive/20 flex items-center justify-center shrink-0">
             <span className="text-destructive font-bold text-xs">!</span>
@@ -73,7 +73,7 @@ export function LoginForm({
         <motion.div
           initial={{ opacity: 0, x: 10 }}
           animate={{ opacity: 1, x: 0 }}
-          className="bg-green-500/10 border border-green-500/20 rounded-2xl p-4 flex items-center gap-3"
+          className="bg-green-500/10 border border-green-500/20 rounded-md p-4 flex items-center gap-3"
         >
           <div className="w-5 h-5 rounded-full bg-green-500/20 flex items-center justify-center shrink-0">
             <span className="text-green-500 font-bold text-xs">✓</span>

--- a/src/components/auth/RegisterForm.tsx
+++ b/src/components/auth/RegisterForm.tsx
@@ -120,7 +120,7 @@ export function RegisterForm({
         <motion.div
           initial={{ opacity: 0, x: -10 }}
           animate={{ opacity: 1, x: 0 }}
-          className="bg-destructive/10 border border-destructive/20 rounded-2xl p-4 flex items-center gap-3"
+          className="bg-destructive/10 border border-destructive/20 rounded-md p-4 flex items-center gap-3"
         >
           <div className="w-5 h-5 rounded-full bg-destructive/20 flex items-center justify-center shrink-0">
             <span className="text-destructive font-bold text-xs">!</span>
@@ -133,7 +133,7 @@ export function RegisterForm({
         <motion.div
           initial={{ opacity: 0, x: 10 }}
           animate={{ opacity: 1, x: 0 }}
-          className="bg-green-500/10 border border-green-500/20 rounded-2xl p-4 flex items-center gap-3"
+          className="bg-green-500/10 border border-green-500/20 rounded-md p-4 flex items-center gap-3"
         >
           <div className="w-5 h-5 rounded-full bg-green-500/20 flex items-center justify-center shrink-0">
             <span className="text-green-500 font-bold text-xs">✓</span>

--- a/src/components/blog/BlogCTA.tsx
+++ b/src/components/blog/BlogCTA.tsx
@@ -46,7 +46,7 @@ export const BlogCTA = () => {
             <motion.button
               whileHover={{ scale: 1.02 }}
               whileTap={{ scale: 0.98 }}
-              className="w-full lg:max-w-xs bg-primary text-white font-bold py-3.5 px-6 rounded-2xl shadow-glow flex items-center justify-center gap-2 group transition-all cursor-pointer text-sm"
+              className="w-full lg:max-w-xs bg-primary text-white font-bold py-3.5 px-6 rounded-md shadow-glow flex items-center justify-center gap-2 group transition-all cursor-pointer text-sm"
             >
               Coba Split Bill
               <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-1" />
@@ -61,7 +61,7 @@ export const BlogCTA = () => {
             return (
               <div key={index} className="flex lg:flex-col gap-4 lg:justify-start">
                 <div
-                  className={`flex-shrink-0 w-12 h-12 rounded-2xl ${step.color} flex items-center justify-center`}
+                  className={`flex-shrink-0 w-12 h-12 rounded-md ${step.color} flex items-center justify-center`}
                 >
                   <Icon className="w-6 h-6" />
                 </div>

--- a/src/components/blog/BlogContent.tsx
+++ b/src/components/blog/BlogContent.tsx
@@ -15,7 +15,7 @@ export const BlogContent = ({ content, className }: BlogContentProps) => {
         "prose prose-blue max-w-none dark:prose-invert",
         "prose-headings:font-bold prose-headings:tracking-tight",
         "prose-p:text-muted-foreground prose-p:leading-relaxed",
-        "prose-img:rounded-2xl prose-img:shadow-lg",
+        "prose-img:rounded-md prose-img:shadow-lg",
         "prose-a:text-primary prose-a:no-underline hover:prose-a:underline",
         "blog-content-container",
         className

--- a/src/components/blog/LatestBlogSlider.tsx
+++ b/src/components/blog/LatestBlogSlider.tsx
@@ -69,7 +69,7 @@ export const LatestBlogSlider = () => {
           {!isLoading && blogs.length >= 3 && (
             <div className="flex-shrink-0 w-[180px] snap-start pr-4 flex items-stretch">
               <Link href="/blog" className="w-full flex">
-                <div className="w-full border-2 border-dashed border-slate-200 rounded-2xl flex flex-col items-center justify-center p-6 text-center hover:border-primary hover:bg-primary/5 transition-all duration-300 group cursor-pointer">
+                <div className="w-full border-2 border-dashed border-slate-200 rounded-md flex flex-col items-center justify-center p-6 text-center hover:border-primary hover:bg-primary/5 transition-all duration-300 group cursor-pointer">
                   <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300">
                     <ArrowRight className="w-6 h-6 text-primary" />
                   </div>

--- a/src/components/collect-money/CollectionDashboard.tsx
+++ b/src/components/collect-money/CollectionDashboard.tsx
@@ -398,7 +398,7 @@ export const CollectionDashboard = ({
           {/* Celebration Card */}
           {progress >= 100 && (
             <div className="mb-6 animate-in zoom-in-95 fade-in duration-500 cursor-default">
-              <div className="relative rounded-2xl p-6 bg-gradient-to-br from-white via-emerald-50/40 to-emerald-50/60 border border-emerald-100/50 shadow-2xl shadow-emerald-600/5 backdrop-blur-md group">
+              <div className="relative rounded-md p-6 bg-gradient-to-br from-white via-emerald-50/40 to-emerald-50/60 border border-emerald-100/50 shadow-2xl shadow-emerald-600/5 backdrop-blur-md group">
                 <div className="absolute -top-3 right-4 p-1 opacity-100 transition-transform group-hover:scale-110 group-hover:rotate-6 z-20">
                   <img
                     alt="Koleksi Selesai"
@@ -487,7 +487,7 @@ export const CollectionDashboard = ({
             </div>
 
             {isAdding && (
-              <div className="bg-white border border-primary/20 p-4 rounded-2xl space-y-4 animate-in fade-in slide-in-from-top-2 mb-4">
+              <div className="bg-white border border-primary/20 p-4 rounded-md space-y-4 animate-in fade-in slide-in-from-top-2 mb-4">
                 <div className="space-y-3">
                   <div className="space-y-1.5">
                     <label className="text-xs font-bold text-foreground/70 ml-1">
@@ -667,7 +667,7 @@ export const CollectionDashboard = ({
                   {/* Add New Button at the beginning */}
                   <Card
                     onClick={() => setIsAddWalletOpen(true)}
-                    className="relative h-[30vw] sm:h-[157px] shrink-0 aspect-square rounded-2xl border border-dashed border-primary/20 flex flex-col items-center justify-center gap-1.5 text-primary/40 hover:text-primary hover:border-primary/40 hover:bg-primary/5 transition-all active:scale-95 cursor-pointer bg-white shadow-none"
+                    className="relative h-[30vw] sm:h-[157px] shrink-0 aspect-square rounded-md border border-dashed border-primary/20 flex flex-col items-center justify-center gap-1.5 text-primary/40 hover:text-primary hover:border-primary/40 hover:bg-primary/5 transition-all active:scale-95 cursor-pointer bg-white shadow-none"
                   >
                     <Plus className="w-5 h-5" />
                     <span className="text-[11px] font-bold">Tambah</span>
@@ -683,7 +683,7 @@ export const CollectionDashboard = ({
                       />
                     ))
                   ) : (
-                    <div className="flex-1 min-w-[200px] h-[30vw] sm:h-[157px] flex flex-col items-center justify-center py-4 px-6 rounded-2xl bg-muted/5 border border-dashed border-muted-foreground/10 text-center">
+                    <div className="flex-1 min-w-[200px] h-[30vw] sm:h-[157px] flex flex-col items-center justify-center py-4 px-6 rounded-md bg-muted/5 border border-dashed border-muted-foreground/10 text-center">
                       <p className="text-[10px] text-muted-foreground leading-tight">
                         Belum ada dompet tersimpan. <br />
                         <span

--- a/src/components/collect-money/CollectionMoreBottomSheet.tsx
+++ b/src/components/collect-money/CollectionMoreBottomSheet.tsx
@@ -63,7 +63,7 @@ export const CollectionMoreBottomSheet = ({
                 onArchive();
                 onClose();
               }}
-              className="w-full flex items-center gap-4 p-4 rounded-2xl hover:bg-primary/5 transition-all active:scale-95 cursor-pointer group"
+              className="w-full flex items-center gap-4 p-4 rounded-md hover:bg-primary/5 transition-all active:scale-95 cursor-pointer group"
             >
               <div className="w-10 h-10 rounded-xl bg-primary/5 flex items-center justify-center group-hover:bg-primary/10 transition-colors">
                 {isArchived ? (
@@ -90,7 +90,7 @@ export const CollectionMoreBottomSheet = ({
                 onDelete();
                 onClose();
               }}
-              className="w-full flex items-center gap-4 p-4 rounded-2xl hover:bg-destructive/5 transition-all active:scale-95 cursor-pointer group"
+              className="w-full flex items-center gap-4 p-4 rounded-md hover:bg-destructive/5 transition-all active:scale-95 cursor-pointer group"
             >
               <div className="w-10 h-10 rounded-xl bg-destructive/5 flex items-center justify-center group-hover:bg-destructive/10 transition-colors">
                 <Trash2 className="w-5 h-5 text-destructive" />

--- a/src/components/collect-money/ShareCollectionReceipt.tsx
+++ b/src/components/collect-money/ShareCollectionReceipt.tsx
@@ -48,7 +48,7 @@ export const ShareCollectionReceipt = React.forwardRef<
       {/* Branding */}
       <div className="relative z-10 w-full flex justify-between items-center mb-12">
         <div className="flex items-center gap-4">
-          <div className="w-16 h-16 bg-white rounded-2xl flex items-center justify-center border border-primary/5 p-2">
+          <div className="w-16 h-16 bg-white rounded-md flex items-center justify-center border border-primary/5 p-2">
             <img
               src="/img/footer-icon.png"
               alt="SplitBill Logo"
@@ -124,7 +124,7 @@ export const ShareCollectionReceipt = React.forwardRef<
 
         <div className="grid grid-cols-2 gap-8 pt-6 border-t border-slate-100">
           <div className="flex items-center gap-4">
-            <div className="w-14 h-14 bg-emerald-50 rounded-2xl flex items-center justify-center">
+            <div className="w-14 h-14 bg-emerald-50 rounded-md flex items-center justify-center">
               <CheckCircle2 className="w-8 h-8 text-emerald-600" />
             </div>
             <div>
@@ -137,7 +137,7 @@ export const ShareCollectionReceipt = React.forwardRef<
             </div>
           </div>
           <div className="flex items-center gap-4">
-            <div className="w-14 h-14 bg-amber-50 rounded-2xl flex items-center justify-center">
+            <div className="w-14 h-14 bg-amber-50 rounded-md flex items-center justify-center">
               <Clock className="w-8 h-8 text-amber-600" />
             </div>
             <div>
@@ -163,7 +163,7 @@ export const ShareCollectionReceipt = React.forwardRef<
             {paidPayers.slice(0, 5).map((payer, idx) => (
               <div
                 key={payer.id}
-                className="bg-emerald-50/50 border border-emerald-100 rounded-3xl p-6 flex items-center justify-between"
+                className="bg-emerald-50/50 border border-emerald-100 rounded-md p-6 flex items-center justify-between"
               >
                 <div className="flex items-center gap-5">
                   <div className="w-16 h-16 rounded-full border-4 border-white overflow-hidden bg-white shrink-0">
@@ -209,7 +209,7 @@ export const ShareCollectionReceipt = React.forwardRef<
             {unpaidPayers.slice(0, 3).map((payer, idx) => (
               <div
                 key={payer.id}
-                className="bg-amber-50/30 border border-amber-100 rounded-3xl p-6 flex items-center justify-between"
+                className="bg-amber-50/30 border border-amber-100 rounded-md p-6 flex items-center justify-between"
               >
                 <div className="flex items-center gap-5">
                   <div className="w-16 h-16 rounded-full border-4 border-white overflow-hidden bg-white shrink-0">

--- a/src/components/goals/ContributionInputBottomSheet.tsx
+++ b/src/components/goals/ContributionInputBottomSheet.tsx
@@ -61,7 +61,7 @@ export const ContributionInputBottomSheet = ({
 
       <div
         className={cn(
-          "absolute bottom-0 w-full max-w-[600px] bg-white rounded-t-3xl shadow-2xl overflow-hidden flex flex-col max-h-[90vh] z-[110]",
+          "absolute bottom-0 w-full max-w-[600px] bg-white rounded-t-md shadow-2xl overflow-hidden flex flex-col max-h-[90vh] z-[110]",
           "animate-in slide-in-from-bottom-full duration-300 ease-out",
         )}
       >

--- a/src/components/goals/GoalDetailView.tsx
+++ b/src/components/goals/GoalDetailView.tsx
@@ -363,507 +363,507 @@ export const GoalDetailView = ({
         />
 
         <div className="px-4">
-            {/* Hero Card - Overlapping */}
-            <div className="mt-4 text-center text-white mb-4">
-              <div className="flex items-center justify-center gap-2 mb-2">
-                <p className="font-bold text-white text-lg leading-none">
-                  {goal.name}
-                </p>
-                <button
-                  onClick={() => onEdit(goal.id)}
-                  className="p-1.5 text-white/70 hover:text-white hover:bg-white/10 rounded-lg transition-all active:scale-95 cursor-pointer"
-                  title="Edit Goal"
-                >
-                  <Pencil className="w-3.5 h-3.5" />
-                </button>
-              </div>
-              <h1 className="text-4xl font-bold tracking-tight mb-4">
-                {formatCurrency(goal.currentAmount)}
-              </h1>
-
-              {goal.deadline && (
-                <div className="flex items-center justify-center gap-2">
-                  <div className="flex items-center gap-1.5 py-1.5">
-                    <Calendar className="w-3 h-3 text-white/70" />
-                    <span className="text-[10px] font-bold text-white/80 uppercase tracking-wider">
-                      Deadline: {formatDate(goal.deadline)}
-                    </span>
-                  </div>
-                  {progress >= 100 ? (
-                    <div className="px-2 py-0.5 bg-emerald-500 text-white text-[9px] font-bold uppercase rounded-full shadow-lg shadow-emerald-500/20">
-                      Achieved in {achievedInDays} Days
-                    </div>
-                  ) : (
-                    <>
-                      {daysLeft !== null && daysLeft > 0 && (
-                        <div className="px-1.5 py-0.5 bg-white text-primary text-[9px] font-bold uppercase rounded-full">
-                          {daysLeft} Days Left
-                        </div>
-                      )}
-                      {daysLeft !== null && daysLeft === 0 && (
-                        <div className="px-1.5 py-0.5 bg-orange-500 text-white text-[9px] font-bold uppercase rounded-full">
-                          Due Today
-                        </div>
-                      )}
-                      {daysLeft !== null && daysLeft < 0 && (
-                        <div className="px-1.5 py-0.5 bg-red-500 text-white text-[9px] font-bold uppercase rounded-full">
-                          Overdue
-                        </div>
-                      )}
-                    </>
-                  )}
-                </div>
-              )}
+          {/* Hero Card - Overlapping */}
+          <div className="mt-4 text-center text-white mb-4">
+            <div className="flex items-center justify-center gap-2 mb-2">
+              <p className="font-bold text-white text-lg leading-none">
+                {goal.name}
+              </p>
+              <button
+                onClick={() => onEdit(goal.id)}
+                className="p-1.5 text-white/70 hover:text-white hover:bg-white/10 rounded-lg transition-all active:scale-95 cursor-pointer"
+                title="Edit Goal"
+              >
+                <Pencil className="w-3.5 h-3.5" />
+              </button>
             </div>
+            <h1 className="text-4xl font-bold tracking-tight mb-4">
+              {formatCurrency(goal.currentAmount)}
+            </h1>
 
-            {/* Celebration Card - Banner Style */}
-            {progress >= 100 && (
-              <div className="mb-6 mt-4 animate-in zoom-in-95 fade-in duration-500 cursor-default">
-                <div className="relative rounded-2xl p-6 bg-gradient-to-br from-white via-emerald-50/40 to-emerald-50/60 border border-emerald-100/50 shadow-2xl shadow-emerald-600/5 backdrop-blur-md group">
-                  {/* Floating Icon Foreground - Pop Up Effect */}
-                  <div className="absolute -top-3 right-4 p-1 opacity-100 transition-transform group-hover:scale-110 group-hover:rotate-6 z-20">
-                    <img
-                      alt="Achieve Goal"
-                      className="w-28 h-28 object-contain "
-                      src="/img/feature-shared-goals-achieved.png"
-                    />
-                  </div>
-
-                  <div className="relative z-10 flex flex-col gap-1">
-                    <div className="flex items-center gap-2">
-                      <h3 className="text-xl font-bold text-primary tracking-tight">
-                        Goal Terpenuhi! 🥳
-                      </h3>
-                    </div>
-
-                    <div className="flex flex-col gap-4">
-                      <p className="text-[11px] text-slate-500 font-bold max-w-[220px] leading-relaxed">
-                        Luar biasa! Target kamu sudah tercapai. Waktunya
-                        eksekusi mimpimu sekarang!
-                      </p>
-                    </div>
-                  </div>
+            {goal.deadline && (
+              <div className="flex items-center justify-center gap-2">
+                <div className="flex items-center gap-1.5 py-1.5">
+                  <Calendar className="w-3 h-3 text-white/70" />
+                  <span className="text-[10px] font-bold text-white/80 uppercase tracking-wider">
+                    Deadline: {formatDate(goal.deadline)}
+                  </span>
                 </div>
+                {progress >= 100 ? (
+                  <div className="px-2 py-0.5 bg-emerald-500 text-white text-[9px] font-bold uppercase rounded-full shadow-lg shadow-emerald-500/20">
+                    Achieved in {achievedInDays} Days
+                  </div>
+                ) : (
+                  <>
+                    {daysLeft !== null && daysLeft > 0 && (
+                      <div className="px-1.5 py-0.5 bg-white text-primary text-[9px] font-bold uppercase rounded-full">
+                        {daysLeft} Days Left
+                      </div>
+                    )}
+                    {daysLeft !== null && daysLeft === 0 && (
+                      <div className="px-1.5 py-0.5 bg-orange-500 text-white text-[9px] font-bold uppercase rounded-full">
+                        Due Today
+                      </div>
+                    )}
+                    {daysLeft !== null && daysLeft < 0 && (
+                      <div className="px-1.5 py-0.5 bg-red-500 text-white text-[9px] font-bold uppercase rounded-full">
+                        Overdue
+                      </div>
+                    )}
+                  </>
+                )}
               </div>
             )}
+          </div>
 
-            <Card className="border-none shadow-md shadow-primary/10 bg-white relative overflow-hidden mb-6">
-              <CardContent className="p-5 space-y-4">
-                <div className="flex items-center justify-between">
-                  <div className="flex flex-col">
-                    <span className="text-xs text-muted-foreground font-bold uppercase tracking-wider">
-                      Progress
-                    </span>
-                    <span className="text-2xl font-bold text-primary">
-                      {progress}%
-                    </span>
-                  </div>
-                  <div className="w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center text-primary">
-                    <TrendingUp className="w-6 h-6" />
-                  </div>
+          {/* Celebration Card - Banner Style */}
+          {progress >= 100 && (
+            <div className="mb-6 mt-4 animate-in zoom-in-95 fade-in duration-500 cursor-default">
+              <div className="relative rounded-md p-6 bg-gradient-to-br from-white via-emerald-50/40 to-emerald-50/60 border border-emerald-100/50 shadow-2xl shadow-emerald-600/5 backdrop-blur-md group">
+                {/* Floating Icon Foreground - Pop Up Effect */}
+                <div className="absolute -top-3 right-4 p-1 opacity-100 transition-transform group-hover:scale-110 group-hover:rotate-6 z-20">
+                  <img
+                    alt="Achieve Goal"
+                    className="w-28 h-28 object-contain "
+                    src="/img/feature-shared-goals-achieved.png"
+                  />
                 </div>
 
-                {/* Progress Bar with Milestones */}
-                <div className="space-y-3">
-                  <div className="w-full bg-muted/40 h-2.5 rounded-full relative">
-                    <div
-                      className={cn(
-                        "h-full rounded-full transition-all duration-1000 ease-out relative z-10",
-                        progress >= 100
-                          ? "bg-gradient-to-r from-emerald-400 to-green-400"
-                          : "bg-primary",
-                      )}
-                      style={{ width: `${progress}%` }}
-                    />
+                <div className="relative z-10 flex flex-col gap-1">
+                  <div className="flex items-center gap-2">
+                    <h3 className="text-xl font-bold text-primary tracking-tight">
+                      Goal Terpenuhi! 🥳
+                    </h3>
+                  </div>
 
-                    {/* Milestone Pins */}
-                    {milestones.map((m) => (
-                      <div
-                        key={m.percent}
-                        className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 z-20"
-                        style={{ left: `${m.percent}%` }}
-                      >
-                        <div
-                          className={cn(
-                            "w-1.5 h-1.5 rounded-full border border-white transition-all duration-500",
-                            progress >= m.percent
-                              ? "bg-white scale-125"
-                              : "bg-muted-foreground/30",
-                          )}
-                        />
-                      </div>
-                    ))}
+                  <div className="flex flex-col gap-4">
+                    <p className="text-[11px] text-slate-500 font-bold max-w-[220px] leading-relaxed">
+                      Luar biasa! Target kamu sudah tercapai. Waktunya
+                      eksekusi mimpimu sekarang!
+                    </p>
                   </div>
                 </div>
+              </div>
+            </div>
+          )}
 
-                <div className="flex justify-between items-center text-xs mt-2">
-                  <span className="text-muted-foreground">Target Goal</span>
-                  <span className="font-bold text-foreground">
-                    {formatCurrency(goal.targetAmount)}
+          <Card className="border-none shadow-md shadow-primary/10 bg-white relative overflow-hidden mb-6">
+            <CardContent className="p-5 space-y-4">
+              <div className="flex items-center justify-between">
+                <div className="flex flex-col">
+                  <span className="text-xs text-muted-foreground font-bold uppercase tracking-wider">
+                    Progress
                   </span>
+                  <span className="text-2xl font-bold text-primary">
+                    {progress}%
+                  </span>
+                </div>
+                <div className="w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center text-primary">
+                  <TrendingUp className="w-6 h-6" />
+                </div>
+              </div>
+
+              {/* Progress Bar with Milestones */}
+              <div className="space-y-3">
+                <div className="w-full bg-muted/40 h-2.5 rounded-full relative">
+                  <div
+                    className={cn(
+                      "h-full rounded-full transition-all duration-1000 ease-out relative z-10",
+                      progress >= 100
+                        ? "bg-gradient-to-r from-emerald-400 to-green-400"
+                        : "bg-primary",
+                    )}
+                    style={{ width: `${progress}%` }}
+                  />
+
+                  {/* Milestone Pins */}
+                  {milestones.map((m) => (
+                    <div
+                      key={m.percent}
+                      className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 z-20"
+                      style={{ left: `${m.percent}%` }}
+                    >
+                      <div
+                        className={cn(
+                          "w-1.5 h-1.5 rounded-full border border-white transition-all duration-500",
+                          progress >= m.percent
+                            ? "bg-white scale-125"
+                            : "bg-muted-foreground/30",
+                        )}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="flex justify-between items-center text-xs mt-2">
+                <span className="text-muted-foreground">Target Goal</span>
+                <span className="font-bold text-foreground">
+                  {formatCurrency(goal.targetAmount)}
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Savings Insight Card */}
+          {(monthlyTarget || estimatedFinish) && remainingAmount > 0 && (
+            <div className="mb-6 animate-in fade-in slide-in-from-bottom-2 duration-500">
+              <div className="bg-primary/5 rounded-md border border-primary/10 overflow-hidden relative">
+                <div className="absolute top-0 right-0 p-3 opacity-10">
+                  <Zap className="w-12 h-12 text-primary" />
+                </div>
+                <div className="p-4 relative">
+                  <div className="flex items-center gap-2 mb-3">
+                    <div className="w-6 h-6 rounded-full bg-primary/10 flex items-center justify-center">
+                      <TrendingUp className="w-3.5 h-3.5 text-primary" />
+                    </div>
+                    <span className="text-[10px] font-black text-primary uppercase tracking-widest">
+                      Savings Insights
+                    </span>
+                  </div>
+
+                  <div className="space-y-3">
+                    {monthlyTarget && (
+                      <div className="flex flex-col">
+                        <span className="text-[10px] text-muted-foreground font-medium flex items-center gap-1">
+                          Target Bulanan <Info className="w-2.5 h-2.5" />
+                        </span>
+                        <p className="text-sm font-bold text-foreground">
+                          Tambah{" "}
+                          <span className="text-primary">
+                            {formatCurrency(monthlyTarget)}
+                          </span>
+                          /bulan lagi untuk capai deadline.
+                        </p>
+                      </div>
+                    )}
+
+                    {estimatedFinish && (
+                      <div className="flex flex-col">
+                        <span className="text-[10px] text-muted-foreground font-medium">
+                          Estimasi Selesai
+                        </span>
+                        <p className="text-sm font-bold text-foreground">
+                          Berdasarkan trenmu, goal ini diprediksi selesai di{" "}
+                          <span className="text-primary">
+                            {estimatedFinish}
+                          </span>
+                          .
+                        </p>
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="mt-4 p-2.5 bg-primary/10 rounded-xl border border-primary/20 animate-in zoom-in-95 duration-700">
+                    <p className="text-[10px] font-bold text-primary text-center">
+                      {getEncouragementMessage()}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Contribution Trends Chart Section */}
+          {chartData.length >= 2 && (
+            <Card className="border-none shadow-soft overflow-hidden mb-6 group cursor-default">
+              <CardContent className="p-5">
+                <div className="flex items-center justify-between mb-4">
+                  <div className="flex flex-col">
+                    <span className="text-[10px] text-muted-foreground font-black uppercase tracking-widest">
+                      Tren Tabungan
+                    </span>
+                    <span className="text-xs font-bold text-foreground mt-0.5">
+                      Pertumbuhan Dana
+                    </span>
+                  </div>
+                  <div className="w-8 h-8 rounded-full bg-primary/5 flex items-center justify-center">
+                    <TrendingUp className="w-4 h-4 text-primary" />
+                  </div>
+                </div>
+
+                <div className="relative h-24 w-full">
+                  <svg
+                    viewBox="0 0 400 100"
+                    className="w-full h-full overflow-visible drop-shadow-[0_4px_8px_rgba(var(--primary-rgb),0.2)]"
+                    preserveAspectRatio="none"
+                  >
+                    <defs>
+                      <linearGradient
+                        id="chartGradient"
+                        x1="0"
+                        y1="0"
+                        x2="0"
+                        y2="1"
+                      >
+                        <stop
+                          offset="0%"
+                          stopColor="var(--primary)"
+                          stopOpacity="0.2"
+                        />
+                        <stop
+                          offset="100%"
+                          stopColor="var(--primary)"
+                          stopOpacity="0.01"
+                        />
+                      </linearGradient>
+                    </defs>
+                    <path
+                      d={`${generateChartPath(chartData, 400, 100)} L 400 100 L 0 100 Z`}
+                      fill="url(#chartGradient)"
+                      className="transition-all duration-1000"
+                    />
+                    <path
+                      d={generateChartPath(chartData, 400, 100)}
+                      fill="none"
+                      stroke="var(--primary)"
+                      strokeWidth="3"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className="transition-all duration-1000"
+                    />
+                  </svg>
+                </div>
+
+                <div className="flex justify-between items-center mt-3 pt-3 border-t border-muted/20">
+                  <div className="flex flex-col">
+                    <span className="text-[9px] text-muted-foreground font-bold uppercase">
+                      Terakhir Update
+                    </span>
+                    <span className="text-[10px] font-bold text-foreground">
+                      {chartData.length > 0
+                        ? formatDate(chartData[chartData.length - 1].date)
+                        : "-"}
+                    </span>
+                  </div>
+                  <div className="text-right flex flex-col">
+                    <span className="text-[9px] text-muted-foreground font-bold uppercase">
+                      Total Kontribusi
+                    </span>
+                    <span className="text-[10px] font-bold text-primary">
+                      {chartData.length} Transaksi
+                    </span>
+                  </div>
                 </div>
               </CardContent>
             </Card>
+          )}
 
-            {/* Savings Insight Card */}
-            {(monthlyTarget || estimatedFinish) && remainingAmount > 0 && (
-              <div className="mb-6 animate-in fade-in slide-in-from-bottom-2 duration-500">
-                <div className="bg-primary/5 rounded-2xl border border-primary/10 overflow-hidden relative">
-                  <div className="absolute top-0 right-0 p-3 opacity-10">
-                    <Zap className="w-12 h-12 text-primary" />
-                  </div>
-                  <div className="p-4 relative">
-                    <div className="flex items-center gap-2 mb-3">
-                      <div className="w-6 h-6 rounded-full bg-primary/10 flex items-center justify-center">
-                        <TrendingUp className="w-3.5 h-3.5 text-primary" />
-                      </div>
-                      <span className="text-[10px] font-black text-primary uppercase tracking-widest">
-                        Savings Insights
-                      </span>
-                    </div>
-
-                    <div className="space-y-3">
-                      {monthlyTarget && (
-                        <div className="flex flex-col">
-                          <span className="text-[10px] text-muted-foreground font-medium flex items-center gap-1">
-                            Target Bulanan <Info className="w-2.5 h-2.5" />
-                          </span>
-                          <p className="text-sm font-bold text-foreground">
-                            Tambah{" "}
-                            <span className="text-primary">
-                              {formatCurrency(monthlyTarget)}
-                            </span>
-                            /bulan lagi untuk capai deadline.
-                          </p>
+          {/* Info Grid */}
+          <div className="grid grid-cols-1 gap-3 mb-6">
+            <Card className="border-none shadow-soft hover:shadow-lg hover:shadow-primary/5 transition-all">
+              <CardContent className="p-4 flex flex-col gap-3">
+                {goal.contributions.length > 0 && (
+                  <>
+                    <div className="flex items-center justify-between border-b border-dashed border-muted pb-2">
+                      <div className="flex items-center gap-2 text-primary">
+                        <div className="w-7 h-7 rounded-lg bg-primary/5 flex items-center justify-center">
+                          <Trophy className="w-4 h-4" />
                         </div>
-                      )}
-
-                      {estimatedFinish && (
-                        <div className="flex flex-col">
-                          <span className="text-[10px] text-muted-foreground font-medium">
-                            Estimasi Selesai
-                          </span>
-                          <p className="text-sm font-bold text-foreground">
-                            Berdasarkan trenmu, goal ini diprediksi selesai di{" "}
-                            <span className="text-primary">
-                              {estimatedFinish}
-                            </span>
-                            .
-                          </p>
-                        </div>
-                      )}
-                    </div>
-
-                    <div className="mt-4 p-2.5 bg-primary/10 rounded-xl border border-primary/20 animate-in zoom-in-95 duration-700">
-                      <p className="text-[10px] font-bold text-primary text-center">
-                        {getEncouragementMessage()}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* Contribution Trends Chart Section */}
-            {chartData.length >= 2 && (
-              <Card className="border-none shadow-soft overflow-hidden mb-6 group cursor-default">
-                <CardContent className="p-5">
-                  <div className="flex items-center justify-between mb-4">
-                    <div className="flex flex-col">
-                      <span className="text-[10px] text-muted-foreground font-black uppercase tracking-widest">
-                        Tren Tabungan
-                      </span>
-                      <span className="text-xs font-bold text-foreground mt-0.5">
-                        Pertumbuhan Dana
-                      </span>
-                    </div>
-                    <div className="w-8 h-8 rounded-full bg-primary/5 flex items-center justify-center">
-                      <TrendingUp className="w-4 h-4 text-primary" />
-                    </div>
-                  </div>
-
-                  <div className="relative h-24 w-full">
-                    <svg
-                      viewBox="0 0 400 100"
-                      className="w-full h-full overflow-visible drop-shadow-[0_4px_8px_rgba(var(--primary-rgb),0.2)]"
-                      preserveAspectRatio="none"
-                    >
-                      <defs>
-                        <linearGradient
-                          id="chartGradient"
-                          x1="0"
-                          y1="0"
-                          x2="0"
-                          y2="1"
-                        >
-                          <stop
-                            offset="0%"
-                            stopColor="var(--primary)"
-                            stopOpacity="0.2"
-                          />
-                          <stop
-                            offset="100%"
-                            stopColor="var(--primary)"
-                            stopOpacity="0.01"
-                          />
-                        </linearGradient>
-                      </defs>
-                      <path
-                        d={`${generateChartPath(chartData, 400, 100)} L 400 100 L 0 100 Z`}
-                        fill="url(#chartGradient)"
-                        className="transition-all duration-1000"
-                      />
-                      <path
-                        d={generateChartPath(chartData, 400, 100)}
-                        fill="none"
-                        stroke="var(--primary)"
-                        strokeWidth="3"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        className="transition-all duration-1000"
-                      />
-                    </svg>
-                  </div>
-
-                  <div className="flex justify-between items-center mt-3 pt-3 border-t border-muted/20">
-                    <div className="flex flex-col">
-                      <span className="text-[9px] text-muted-foreground font-bold uppercase">
-                        Terakhir Update
-                      </span>
-                      <span className="text-[10px] font-bold text-foreground">
-                        {chartData.length > 0
-                          ? formatDate(chartData[chartData.length - 1].date)
-                          : "-"}
-                      </span>
-                    </div>
-                    <div className="text-right flex flex-col">
-                      <span className="text-[9px] text-muted-foreground font-bold uppercase">
-                        Total Kontribusi
-                      </span>
-                      <span className="text-[10px] font-bold text-primary">
-                        {chartData.length} Transaksi
-                      </span>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            )}
-
-            {/* Info Grid */}
-            <div className="grid grid-cols-1 gap-3 mb-6">
-              <Card className="border-none shadow-soft hover:shadow-lg hover:shadow-primary/5 transition-all">
-                <CardContent className="p-4 flex flex-col gap-3">
-                  {goal.contributions.length > 0 && (
-                    <>
-                      <div className="flex items-center justify-between border-b border-dashed border-muted pb-2">
-                        <div className="flex items-center gap-2 text-primary">
-                          <div className="w-7 h-7 rounded-lg bg-primary/5 flex items-center justify-center">
-                            <Trophy className="w-4 h-4" />
-                          </div>
-                          <span className="text-[10px] font-bold uppercase tracking-wider">
-                            Leaderboard 🏆
-                          </span>
-                        </div>
-                      </div>
-
-                      {/* Leaderboard Grid */}
-                      <div className="grid grid-cols-2 gap-3 mb-2">
-                        {/* Top Contributor */}
-                        <div className="relative p-3 bg-gradient-to-br from-yellow-50 to-white rounded-2xl border border-yellow-100/50 animate-in slide-in-from-left duration-500">
-                          <div className="absolute top-2 right-2">
-                            <Trophy className="w-4 h-4 text-yellow-500 drop-shadow-sm" />
-                          </div>
-                          <div className="flex flex-col items-center gap-2">
-                            <div className="w-12 h-12 rounded-full border-2 border-yellow-200 shadow-soft overflow-hidden bg-white ring-4 ring-yellow-400/10 transition-transform hover:scale-110 duration-300">
-                              <img
-                                src={`${AVATAR_BASE_URL}${encodeURIComponent(topContributor?.id || "")}`}
-                                alt={topContributor?.id}
-                                className="w-full h-full object-cover"
-                              />
-                            </div>
-                            <div className="text-center">
-                              <p className="text-[9px] font-bold text-yellow-600 uppercase tracking-tighter">
-                                Biggest Contributor
-                              </p>
-                              <p className="text-xs font-bold text-foreground truncate max-w-[80px] mx-auto">
-                                {topContributor?.id}
-                              </p>
-                              <p className="text-[10px] font-bold text-primary">
-                                {formatCurrency(topContributor?.amount || 0)}
-                              </p>
-                            </div>
-                          </div>
-                        </div>
-
-                        {/* Most Frequent Saver */}
-                        <div className="relative p-3 bg-gradient-to-br from-orange-50 to-white rounded-2xl border border-orange-100/50 animate-in slide-in-from-right duration-500 delay-150">
-                          <div className="absolute top-2 right-2">
-                            <Zap className="w-4 h-4 text-orange-500 drop-shadow-sm" />
-                          </div>
-                          <div className="flex flex-col items-center gap-2">
-                            <div className="w-12 h-12 rounded-full border-2 border-orange-200 shadow-soft overflow-hidden bg-white ring-4 ring-orange-400/10 transition-transform hover:scale-110 duration-300">
-                              <img
-                                src={`${AVATAR_BASE_URL}${encodeURIComponent(mostFrequentSaver?.id || "")}`}
-                                alt={mostFrequentSaver?.id}
-                                className="w-full h-full object-cover"
-                              />
-                            </div>
-                            <div className="text-center">
-                              <p className="text-[9px] font-bold text-orange-600 uppercase tracking-tighter">
-                                Most Frequent Saver
-                              </p>
-                              <p className="text-xs font-bold text-foreground truncate max-w-[80px] mx-auto">
-                                {mostFrequentSaver?.id}
-                              </p>
-                              <p className="text-[10px] font-bold text-primary">
-                                {mostFrequentSaver?.count || 0} Tabungan
-                              </p>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </>
-                  )}
-
-                  <div className="flex items-center justify-between border-b border-dashed border-muted pb-2 mt-2">
-                    <div className="flex items-center gap-2 text-purple-600">
-                      <div className="w-7 h-7 rounded-lg bg-purple-50 flex items-center justify-center">
-                        <Users className="w-4 h-4" />
-                      </div>
-                      <span className="text-[10px] font-bold uppercase tracking-wider">
-                        Semua Kontributor
-                      </span>
-                    </div>
-                    <span className="text-[10px] font-bold text-muted-foreground uppercase">
-                      {goal.members.length} Orang
-                    </span>
-                  </div>
-
-                  <div className="grid grid-cols-1 gap-2">
-                    {memberContributions.map((member, i) => (
-                      <div
-                        key={i}
-                        className="flex items-center justify-between py-1 animate-in fade-in"
-                        style={{ animationDelay: `${i * 50}ms` }}
-                      >
-                        <div className="flex items-center gap-2">
-                          <div className="w-8 h-8 rounded-full border-2 border-white shadow-sm overflow-hidden bg-white shrink-0">
-                            <img
-                              src={`${AVATAR_BASE_URL}${encodeURIComponent(member.id)}`}
-                              alt={member.id}
-                              className="w-full h-full object-cover"
-                            />
-                          </div>
-                          <span className="text-xs font-bold text-foreground">
-                            {member.id}
-                          </span>
-                        </div>
-                        <span className="text-xs font-bold text-primary">
-                          {formatCurrency(member.amount)}
+                        <span className="text-[10px] font-bold uppercase tracking-wider">
+                          Leaderboard 🏆
                         </span>
                       </div>
-                    ))}
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
+                    </div>
 
-            {/* History Section */}
-            <div className="space-y-4">
-              <div className="flex items-center justify-between px-1">
-                <h3 className="text-sm font-bold text-foreground/70 flex items-center gap-2">
-                  <History className="w-4 h-4" /> Riwayat Tabungan
-                </h3>
-              </div>
-
-              {goal.contributions.length === 0 ? (
-                <Card className="border-none shadow-soft overflow-hidden">
-                  <CardContent className="p-4">
-                    <EmptyState
-                      message="Belum ada transaksi"
-                      subtitle="Yuk mulai menabung sekarang!"
-                      icon={History}
-                      className="bg-primary/5"
-                    />
-                  </CardContent>
-                </Card>
-              ) : (
-                <div className="space-y-3">
-                  {(showAllTransactions
-                    ? goal.contributions
-                    : goal.contributions.slice(0, 3)
-                  ).map((contribution) => (
-                    <Card
-                      key={contribution.id}
-                      className="border-none shadow-soft hover:shadow-lg hover:shadow-primary/5 transition-all group"
-                    >
-                      <CardContent className="p-4 flex items-center justify-between">
-                        <div className="flex items-center gap-4">
-                          <div className="w-10 h-10 rounded-full border-2 border-white shadow-soft overflow-hidden bg-white shrink-0">
+                    {/* Leaderboard Grid */}
+                    <div className="grid grid-cols-2 gap-3 mb-2">
+                      {/* Top Contributor */}
+                      <div className="relative p-3 bg-gradient-to-br from-yellow-50 to-white rounded-md border border-yellow-100/50 animate-in slide-in-from-left duration-500">
+                        <div className="absolute top-2 right-2">
+                          <Trophy className="w-4 h-4 text-yellow-500 drop-shadow-sm" />
+                        </div>
+                        <div className="flex flex-col items-center gap-2">
+                          <div className="w-12 h-12 rounded-full border-2 border-yellow-200 shadow-soft overflow-hidden bg-white ring-4 ring-yellow-400/10 transition-transform hover:scale-110 duration-300">
                             <img
-                              src={`${AVATAR_BASE_URL}${encodeURIComponent(contribution.memberId)}`}
-                              alt={contribution.memberId}
+                              src={`${AVATAR_BASE_URL}${encodeURIComponent(topContributor?.id || "")}`}
+                              alt={topContributor?.id}
                               className="w-full h-full object-cover"
                             />
                           </div>
-                          <div className="space-y-0.5">
-                            <p className="font-bold text-xs text-foreground">
-                              {contribution.memberId}
+                          <div className="text-center">
+                            <p className="text-[9px] font-bold text-yellow-600 uppercase tracking-tighter">
+                              Biggest Contributor
                             </p>
-                            <div className="flex items-center gap-1 opacity-60">
-                              <History className="w-2.5 h-2.5" />
-                              <p className="text-[9px] font-medium">
-                                {getRelativeTime(contribution.date)}
-                              </p>
-                            </div>
-                            {contribution.note && (
-                              <p className="text-[10px] text-muted-foreground mt-1 bg-primary/5 px-2 py-0.5 rounded-md inline-block border border-primary/10">
-                                {contribution.note}
-                              </p>
-                            )}
+                            <p className="text-xs font-bold text-foreground truncate max-w-[80px] mx-auto">
+                              {topContributor?.id}
+                            </p>
+                            <p className="text-[10px] font-bold text-primary">
+                              {formatCurrency(topContributor?.amount || 0)}
+                            </p>
                           </div>
                         </div>
-                        <div className="flex flex-col items-end gap-1.5">
-                          <span className="font-bold text-xs text-green-600">
-                            +{formatCurrency(contribution.amount)}
-                          </span>
-                          <button
-                            onClick={() =>
-                              removeContribution(goal.id, contribution.id)
-                            }
-                            className="w-8 h-8 rounded-full flex items-center justify-center text-muted-foreground/30 hover:text-destructive hover:bg-destructive/10 transition-colors cursor-pointer"
-                          >
-                            <Trash2 className="w-4 h-4" />
-                          </button>
-                        </div>
-                      </CardContent>
-                    </Card>
-                  ))}
+                      </div>
 
-                  {goal.contributions.length > 3 && (
-                    <button
-                      onClick={() =>
-                        setShowAllTransactions(!showAllTransactions)
-                      }
-                      className="w-full py-3 flex items-center justify-center gap-2 text-xs font-bold text-primary hover:bg-primary/5 rounded-sm transition-colors mt-2 cursor-pointer"
-                    >
-                      {showAllTransactions ? (
-                        <>
-                          Sembunyikan <ChevronUp className="w-4 h-4" />
-                        </>
-                      ) : (
-                        <>
-                          Lihat Selengkapnya ({goal.contributions.length - 3}{" "}
-                          Lainnya) <ChevronDown className="w-4 h-4" />
-                        </>
-                      )}
-                    </button>
-                  )}
+                      {/* Most Frequent Saver */}
+                      <div className="relative p-3 bg-gradient-to-br from-orange-50 to-white rounded-md border border-orange-100/50 animate-in slide-in-from-right duration-500 delay-150">
+                        <div className="absolute top-2 right-2">
+                          <Zap className="w-4 h-4 text-orange-500 drop-shadow-sm" />
+                        </div>
+                        <div className="flex flex-col items-center gap-2">
+                          <div className="w-12 h-12 rounded-full border-2 border-orange-200 shadow-soft overflow-hidden bg-white ring-4 ring-orange-400/10 transition-transform hover:scale-110 duration-300">
+                            <img
+                              src={`${AVATAR_BASE_URL}${encodeURIComponent(mostFrequentSaver?.id || "")}`}
+                              alt={mostFrequentSaver?.id}
+                              className="w-full h-full object-cover"
+                            />
+                          </div>
+                          <div className="text-center">
+                            <p className="text-[9px] font-bold text-orange-600 uppercase tracking-tighter">
+                              Most Frequent Saver
+                            </p>
+                            <p className="text-xs font-bold text-foreground truncate max-w-[80px] mx-auto">
+                              {mostFrequentSaver?.id}
+                            </p>
+                            <p className="text-[10px] font-bold text-primary">
+                              {mostFrequentSaver?.count || 0} Tabungan
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </>
+                )}
+
+                <div className="flex items-center justify-between border-b border-dashed border-muted pb-2 mt-2">
+                  <div className="flex items-center gap-2 text-purple-600">
+                    <div className="w-7 h-7 rounded-lg bg-purple-50 flex items-center justify-center">
+                      <Users className="w-4 h-4" />
+                    </div>
+                    <span className="text-[10px] font-bold uppercase tracking-wider">
+                      Semua Kontributor
+                    </span>
+                  </div>
+                  <span className="text-[10px] font-bold text-muted-foreground uppercase">
+                    {goal.members.length} Orang
+                  </span>
                 </div>
-              )}
+
+                <div className="grid grid-cols-1 gap-2">
+                  {memberContributions.map((member, i) => (
+                    <div
+                      key={i}
+                      className="flex items-center justify-between py-1 animate-in fade-in"
+                      style={{ animationDelay: `${i * 50}ms` }}
+                    >
+                      <div className="flex items-center gap-2">
+                        <div className="w-8 h-8 rounded-full border-2 border-white shadow-sm overflow-hidden bg-white shrink-0">
+                          <img
+                            src={`${AVATAR_BASE_URL}${encodeURIComponent(member.id)}`}
+                            alt={member.id}
+                            className="w-full h-full object-cover"
+                          />
+                        </div>
+                        <span className="text-xs font-bold text-foreground">
+                          {member.id}
+                        </span>
+                      </div>
+                      <span className="text-xs font-bold text-primary">
+                        {formatCurrency(member.amount)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* History Section */}
+          <div className="space-y-4">
+            <div className="flex items-center justify-between px-1">
+              <h3 className="text-sm font-bold text-foreground/70 flex items-center gap-2">
+                <History className="w-4 h-4" /> Riwayat Tabungan
+              </h3>
             </div>
+
+            {goal.contributions.length === 0 ? (
+              <Card className="border-none shadow-soft overflow-hidden">
+                <CardContent className="p-4">
+                  <EmptyState
+                    message="Belum ada transaksi"
+                    subtitle="Yuk mulai menabung sekarang!"
+                    icon={History}
+                    className="bg-primary/5"
+                  />
+                </CardContent>
+              </Card>
+            ) : (
+              <div className="space-y-3">
+                {(showAllTransactions
+                  ? goal.contributions
+                  : goal.contributions.slice(0, 3)
+                ).map((contribution) => (
+                  <Card
+                    key={contribution.id}
+                    className="border-none shadow-soft hover:shadow-lg hover:shadow-primary/5 transition-all group"
+                  >
+                    <CardContent className="p-4 flex items-center justify-between">
+                      <div className="flex items-center gap-4">
+                        <div className="w-10 h-10 rounded-full border-2 border-white shadow-soft overflow-hidden bg-white shrink-0">
+                          <img
+                            src={`${AVATAR_BASE_URL}${encodeURIComponent(contribution.memberId)}`}
+                            alt={contribution.memberId}
+                            className="w-full h-full object-cover"
+                          />
+                        </div>
+                        <div className="space-y-0.5">
+                          <p className="font-bold text-xs text-foreground">
+                            {contribution.memberId}
+                          </p>
+                          <div className="flex items-center gap-1 opacity-60">
+                            <History className="w-2.5 h-2.5" />
+                            <p className="text-[9px] font-medium">
+                              {getRelativeTime(contribution.date)}
+                            </p>
+                          </div>
+                          {contribution.note && (
+                            <p className="text-[10px] text-muted-foreground mt-1 bg-primary/5 px-2 py-0.5 rounded-md inline-block border border-primary/10">
+                              {contribution.note}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                      <div className="flex flex-col items-end gap-1.5">
+                        <span className="font-bold text-xs text-green-600">
+                          +{formatCurrency(contribution.amount)}
+                        </span>
+                        <button
+                          onClick={() =>
+                            removeContribution(goal.id, contribution.id)
+                          }
+                          className="w-8 h-8 rounded-full flex items-center justify-center text-muted-foreground/30 hover:text-destructive hover:bg-destructive/10 transition-colors cursor-pointer"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+
+                {goal.contributions.length > 3 && (
+                  <button
+                    onClick={() =>
+                      setShowAllTransactions(!showAllTransactions)
+                    }
+                    className="w-full py-3 flex items-center justify-center gap-2 text-xs font-bold text-primary hover:bg-primary/5 rounded-sm transition-colors mt-2 cursor-pointer"
+                  >
+                    {showAllTransactions ? (
+                      <>
+                        Sembunyikan <ChevronUp className="w-4 h-4" />
+                      </>
+                    ) : (
+                      <>
+                        Lihat Selengkapnya ({goal.contributions.length - 3}{" "}
+                        Lainnya) <ChevronDown className="w-4 h-4" />
+                      </>
+                    )}
+                  </button>
+                )}
+              </div>
+            )}
           </div>
         </div>
+      </div>
 
       {/* Sticky CTA Footer - Matched with Split Bill Page logic */}
       <div className="sticky bottom-0 w-full z-[110] pointer-events-none flex justify-center mt-auto">
@@ -871,7 +871,7 @@ export const GoalDetailView = ({
           <div className="bg-background px-4 pb-4 pt-2 flex flex-col gap-3 border-t border-muted/20 shadow-[-0_-10px_30px_rgba(0,0,0,0.02)]">
             <Button
               onClick={() => setIsContributionSheetOpen(true)}
-              className="w-full h-14 text-lg font-bold rounded-2xl shadow-xl shadow-primary/20 bg-primary text-white active:scale-95 transition-all cursor-pointer"
+              className="w-full h-14 text-lg font-bold rounded-md shadow-xl shadow-primary/20 bg-primary text-white active:scale-95 transition-all cursor-pointer"
             >
               <Plus className="w-5 h-5 mr-2" /> Tambah Tabungan
             </Button>
@@ -879,12 +879,12 @@ export const GoalDetailView = ({
         </div>
       </div>
 
-        {/* Modals */}
-        <ContributionInputBottomSheet
-          isOpen={isContributionSheetOpen}
-          onClose={() => setIsContributionSheetOpen(false)}
-          goal={goal}
-        />
+      {/* Modals */}
+      <ContributionInputBottomSheet
+        isOpen={isContributionSheetOpen}
+        onClose={() => setIsContributionSheetOpen(false)}
+        goal={goal}
+      />
 
       <ConfirmationModal
         isOpen={showDeleteConfirm}

--- a/src/components/goals/GoalFormBottomSheet.tsx
+++ b/src/components/goals/GoalFormBottomSheet.tsx
@@ -132,7 +132,7 @@ export const GoalFormBottomSheet = ({
 
       <div
         className={cn(
-          "absolute bottom-0 w-full max-w-[600px] bg-white rounded-t-3xl shadow-2xl overflow-hidden flex flex-col max-h-[90vh]",
+          "absolute bottom-0 w-full max-w-[600px] bg-white rounded-t-md shadow-2xl overflow-hidden flex flex-col max-h-[90vh]",
           "animate-in slide-in-from-bottom-full duration-300 ease-out",
         )}
       >

--- a/src/components/goals/ShareGoalReceipt.tsx
+++ b/src/components/goals/ShareGoalReceipt.tsx
@@ -52,7 +52,7 @@ export const ShareGoalReceipt = React.forwardRef<
       {/* Branding */}
       <div className="relative z-10 w-full flex justify-between items-center mb-12">
         <div className="flex items-center gap-4">
-          <div className="w-16 h-16 bg-white rounded-2xl flex items-center justify-center border border-primary/5 p-2">
+          <div className="w-16 h-16 bg-white rounded-md flex items-center justify-center border border-primary/5 p-2">
             <img
               src="/img/footer-icon.png"
               alt="SplitBill Logo"
@@ -128,7 +128,7 @@ export const ShareGoalReceipt = React.forwardRef<
 
         <div className="grid grid-cols-2 gap-8 pt-6 border-t border-slate-100">
           <div className="flex items-center gap-4">
-            <div className="w-14 h-14 bg-purple-50 rounded-2xl flex items-center justify-center">
+            <div className="w-14 h-14 bg-purple-50 rounded-md flex items-center justify-center">
               <Users className="w-8 h-8 text-purple-600" />
             </div>
             <div>
@@ -141,7 +141,7 @@ export const ShareGoalReceipt = React.forwardRef<
             </div>
           </div>
           <div className="flex items-center gap-4">
-            <div className="w-14 h-14 bg-emerald-50 rounded-2xl flex items-center justify-center">
+            <div className="w-14 h-14 bg-emerald-50 rounded-md flex items-center justify-center">
               <TrendingUp className="w-8 h-8 text-emerald-600" />
             </div>
             <div>
@@ -170,7 +170,7 @@ export const ShareGoalReceipt = React.forwardRef<
             return (
               <div
                 key={memberId}
-                className="bg-white border border-slate-100 rounded-3xl p-6 flex items-center justify-between"
+                className="bg-white border border-slate-100 rounded-md p-6 flex items-center justify-between"
               >
                 <div className="flex items-center gap-5">
                   <div className="w-16 h-16 rounded-full border-4 border-white overflow-hidden bg-white shrink-0">

--- a/src/components/history/TransactionFilterBottomSheet.tsx
+++ b/src/components/history/TransactionFilterBottomSheet.tsx
@@ -70,7 +70,7 @@ export const TransactionFilterBottomSheet = ({
 
       <div
         className={cn(
-          "absolute bottom-0 w-full max-w-[600px] bg-white rounded-t-3xl shadow-2xl overflow-hidden flex flex-col max-h-[90vh]",
+          "absolute bottom-0 w-full max-w-[600px] bg-white rounded-t-md shadow-2xl overflow-hidden flex flex-col max-h-[90vh]",
           "animate-in slide-in-from-bottom-full duration-300 ease-out",
         )}
       >

--- a/src/components/home/AdsCarousel.tsx
+++ b/src/components/home/AdsCarousel.tsx
@@ -44,7 +44,7 @@ export const AdsCarousel = () => {
     const isExternal = ad.url.startsWith("http");
 
     const Content = (
-      <div className="relative aspect-[1080/1350] w-[178px] overflow-hidden rounded-2xl shadow-soft border border-white/50 backdrop-blur-sm">
+      <div className="relative aspect-[1080/1350] w-[178px] overflow-hidden rounded-md shadow-soft border border-white/50 backdrop-blur-sm">
         <Image
           src={ad.image}
           alt={ad.alt}

--- a/src/components/home/Banner.tsx
+++ b/src/components/home/Banner.tsx
@@ -248,7 +248,7 @@ export const Banner = () => {
               "aspect-[1080/608] shrink-0 block relative z-20 group rounded-sm md:rounded-lg overflow-hidden transition-all duration-300"
             )}
           >
-            <div className="relative h-full w-full overflow-hidden cursor-pointer leading-[0] rounded-sm md:rounded-lg">
+            <div className="relative h-full w-full overflow-hidden cursor-pointer leading-[0] rounded-sm md:rounded-md">
               {/* Skeleton Loader */}
               {!loadedImages[banner.id] && (
                 <div className="absolute inset-0 z-10 bg-gradient-to-r from-gray-200 via-gray-100 to-gray-200 bg-[length:200%_100%] animate-[shimmer_1.5s_infinite] h-full w-full" />

--- a/src/components/home/FAQCard.tsx
+++ b/src/components/home/FAQCard.tsx
@@ -9,7 +9,7 @@ export const FAQCard = ({ compact = false }: { compact?: boolean }) => {
   return (
     <section className="animate-in fade-in slide-in-from-bottom-4 duration-500">
       <Link href="/faq">
-        <Card className="group relative overflow-hidden bg-white border border-slate-100 shadow-soft hover:shadow-md transition-all duration-300 cursor-pointer rounded-2xl">
+        <Card className="group relative overflow-hidden bg-white border border-slate-100 shadow-soft hover:shadow-md transition-all duration-300 cursor-pointer rounded-md">
           <CardContent className="relative p-4">
             <div className="flex items-center justify-between gap-4">
               <div className="flex items-center gap-3 flex-1">

--- a/src/components/home/FeatureHighlights.tsx
+++ b/src/components/home/FeatureHighlights.tsx
@@ -116,8 +116,8 @@ export const FeatureHighlights = ({ heroMode = false }: FeatureHighlightsProps) 
   // ── CARD MODE (default) ──────────────────────────────────────────────────
   return (
     <Link href="/history?tab=split-bill" className="block">
-      <div className="relative px-[1.5px] pt-[1.5px] pb-[4px] rounded-2xl bg-gradient-to-r from-violet-400 via-pink-400 to-primary/70 shadow-lg shadow-pink-500/5 group hover:scale-[1.01] active:scale-[0.99] transition-all duration-300 overflow-hidden cursor-pointer">
-        <div className="relative overflow-hidden bg-white rounded-[calc(1rem-1.5px)] z-10 p-5 space-y-4">
+      <div className="relative px-[1.5px] pt-[1.5px] pb-[4px] rounded-md bg-gradient-to-r from-violet-400 via-pink-400 to-primary/70 shadow-lg shadow-pink-500/5 group hover:scale-[1.01] active:scale-[0.99] transition-all duration-300 overflow-hidden cursor-pointer">
+        <div className="relative overflow-hidden bg-white rounded-[calc(var(--radius-md)-1.5px)] z-10 p-5 space-y-4">
           {/* Subtle background glow */}
           <div className="absolute top-0 right-0 w-24 h-24 bg-pink-500/5 rounded-full blur-2xl -mr-6 -mt-6 pointer-events-none" />
 

--- a/src/components/home/OngoingSplitBillCard.tsx
+++ b/src/components/home/OngoingSplitBillCard.tsx
@@ -119,10 +119,10 @@ export const OngoingSplitBillCard = () => {
       <div
         onClick={handleCardClick}
         className={cn(
-          "relative px-[1.5px] pt-[1.5px] pb-[4px] rounded-2xl bg-gradient-to-r from-violet-400 via-pink-400 to-primary/70 shadow-lg shadow-pink-500/5 transition-all duration-300 overflow-hidden cursor-pointer h-full group hover:scale-[1.01] active:scale-[0.99]"
+          "relative px-[1.5px] pt-[1.5px] pb-[4px] rounded-md bg-gradient-to-r from-violet-400 via-pink-400 to-primary/70 shadow-lg shadow-pink-500/5 transition-all duration-300 overflow-hidden cursor-pointer h-full group hover:scale-[1.01] active:scale-[0.99]"
         )}
       >
-        <div className="relative overflow-hidden bg-white rounded-[calc(1rem-1.5px)] z-10 p-4 space-y-3 h-full flex flex-col">
+        <div className="relative overflow-hidden bg-white rounded-[calc(var(--radius-md)-1.5px)] z-10 p-4 space-y-3 h-full flex flex-col">
           {/* Subtle background glow */}
           <div className="absolute top-0 right-0 w-24 h-24 bg-pink-500/5 rounded-full blur-2xl -mr-6 -mt-6 pointer-events-none" />
 

--- a/src/components/home/ShareEncouragement.tsx
+++ b/src/components/home/ShareEncouragement.tsx
@@ -14,8 +14,8 @@ export const ShareEncouragement = ({ isCompact = false }: ShareEncouragementProp
     <Link
       href="/split-later"
       className={`relative block w-full bg-[#2E6FF3] overflow-hidden shadow-soft transition-all duration-500 group cursor-pointer active:scale-[0.99] ${isCompact
-        ? "rounded-2xl"
-        : "rounded-2xl lg:rounded-xl"
+        ? "rounded-md"
+        : "rounded-md lg:rounded-lg"
         }`}
     >
       {/* Background styling for the right side */}
@@ -63,7 +63,7 @@ export const ShareEncouragement = ({ isCompact = false }: ShareEncouragementProp
           <div className="pt-1">
             <span className={`inline-flex bg-white text-[#2E6FF3] font-bold rounded-xl items-center justify-center gap-2 hover:bg-blue-50 transition-all shadow-md group-hover:translate-x-1 duration-300 ${isCompact
               ? "text-[10px] px-4 py-2"
-              : "text-[12px] lg:text-base px-5 lg:px-8 py-2.5 lg:py-4 lg:rounded-2xl"
+              : "text-[12px] lg:text-base px-5 lg:px-8 py-2.5 lg:py-4 lg:rounded-md"
               }`}>
               Coba Sekarang <ArrowRight className={`w-3.5 h-3.5 ${isCompact ? "" : "lg:w-5 lg:h-5"}`} />
             </span>

--- a/src/components/home/SplitBillHeroCard.tsx
+++ b/src/components/home/SplitBillHeroCard.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { HeroBanner } from "@/components/ui/HeroBanner";
 
 const HeroFloatingCard = () => (
-  <div className="bg-white rounded-2xl shadow-[0_8px_30px_rgb(0,0,0,0.08)] p-3.5 border border-slate-100/60 min-w-[150px]">
+  <div className="bg-white rounded-md shadow-[0_8px_30px_rgb(0,0,0,0.08)] p-3.5 border border-slate-100/60 min-w-[150px]">
     <p className="text-[10px] text-slate-500 font-medium mb-0.5">
       Total Tagihan
     </p>

--- a/src/components/home/VisualFlowPreview.tsx
+++ b/src/components/home/VisualFlowPreview.tsx
@@ -52,7 +52,7 @@ export const VisualFlowPreview = () => {
               key={step.number}
               className="flex-shrink-0 w-[180px] snap-start pb-2"
             >
-              <div className="relative bg-white border border-slate-100 backdrop-blur-sm rounded-2xl overflow-hidden shadow-soft hover:shadow-lg hover:shadow-primary/5 transition-all duration-500 group h-full flex flex-col">
+              <div className="relative bg-white border border-slate-100 backdrop-blur-sm rounded-md overflow-hidden shadow-soft hover:shadow-lg hover:shadow-primary/5 transition-all duration-500 group h-full flex flex-col">
                 {/* Step Image */}
                 <div className="relative w-full aspect-square overflow-hidden bg-muted">
                   <Image

--- a/src/components/homepage/BlogSectionHomepage.tsx
+++ b/src/components/homepage/BlogSectionHomepage.tsx
@@ -135,7 +135,7 @@ export const BlogSectionHomepage = () => {
               {!isLoading && blogs.length >= 3 && (
                 <div className="flex-shrink-0 w-[180px] sm:w-[220px] snap-start pr-4 flex items-stretch">
                   <Link href="/blog" className="w-full flex">
-                    <div className="w-full border-2 border-dashed border-slate-200 rounded-2xl flex flex-col items-center justify-center p-6 text-center hover:border-primary hover:bg-primary/5 transition-all duration-300 group cursor-pointer">
+                    <div className="w-full border-2 border-dashed border-slate-200 rounded-md flex flex-col items-center justify-center p-6 text-center hover:border-primary hover:bg-primary/5 transition-all duration-300 group cursor-pointer">
                       <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300">
                         <ArrowRight className="w-6 h-6 text-primary" />
                       </div>

--- a/src/components/homepage/CTABannerSection.tsx
+++ b/src/components/homepage/CTABannerSection.tsx
@@ -39,21 +39,22 @@ export const CTABannerSection = () => {
       {/* Soft bottom spotlight */}
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_80%_50%_at_50%_110%,rgba(71,159,234,0.16),transparent)]" />
 
-      {/* Aurora blobs — matches Hero */}
+      {/* Aurora blobs — single settle-in pass, not infinite (same reasoning as Hero: an
+          endless loop never lets the page look visually stable, hurting Speed Index). */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
         <motion.div
           animate={{ scale: [1, 1.12, 1], x: [0, 24, 0], y: [0, -18, 0], opacity: [0.28, 0.42, 0.28] }}
-          transition={{ repeat: Infinity, duration: 9, ease: "easeInOut" }}
+          transition={{ repeat: 1, duration: 2.5, ease: "easeInOut" }}
           className="absolute top-[-15%] right-[-8%] w-[50vw] h-[50vw] max-w-[700px] max-h-[700px] rounded-full bg-primary/25 blur-[100px]"
         />
         <motion.div
           animate={{ scale: [1, 1.15, 1], x: [0, -22, 0], y: [0, 18, 0], opacity: [0.18, 0.32, 0.18] }}
-          transition={{ repeat: Infinity, duration: 11, ease: "easeInOut", delay: 1.5 }}
+          transition={{ repeat: 1, duration: 2.5, ease: "easeInOut", delay: 0.3 }}
           className="absolute bottom-[-15%] left-[-10%] w-[45vw] h-[45vw] max-w-[600px] max-h-[600px] rounded-full bg-sky-300/25 blur-[90px]"
         />
         <motion.div
           animate={{ scale: [1, 1.1, 1], opacity: [0.15, 0.28, 0.15] }}
-          transition={{ repeat: Infinity, duration: 7, ease: "easeInOut", delay: 3 }}
+          transition={{ repeat: 1, duration: 2.5, ease: "easeInOut", delay: 0.6 }}
           className="absolute top-[18%] right-[8%] w-[25vw] h-[25vw] max-w-[350px] max-h-[350px] rounded-full bg-emerald-300/20 blur-[80px]"
         />
       </div>

--- a/src/components/homepage/ComparisonSection.tsx
+++ b/src/components/homepage/ComparisonSection.tsx
@@ -55,7 +55,7 @@ export const ComparisonSection = () => {
         </div>
 
         {/* Comparison grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 lg:gap-12">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 lg:gap-8">
           {/* Without SplitBill Card */}
           <motion.div
             initial={{ opacity: 0, x: -30 }}

--- a/src/components/homepage/FeaturesSection.tsx
+++ b/src/components/homepage/FeaturesSection.tsx
@@ -154,7 +154,7 @@ export const FeaturesSection = () => {
                       <div>
                         {/* Card Icon Container */}
                         <div className="flex items-center justify-between mb-4 sm:mb-6">
-                          <div className={`w-12 h-12 sm:w-16 sm:h-16 ${feat.bgLight} ${feat.bgHover} rounded-xl sm:rounded-2xl flex items-center justify-center p-2 sm:p-2.5 transition-all duration-300 group-hover:scale-105 relative`}>
+                          <div className={`w-12 h-12 sm:w-16 sm:h-16 ${feat.bgLight} ${feat.bgHover} rounded-xl sm:rounded-md flex items-center justify-center p-2 sm:p-2.5 transition-all duration-300 group-hover:scale-105 relative`}>
                             <Image
                               src={feat.imageSrc}
                               alt={feat.title}

--- a/src/components/homepage/HeroSection.tsx
+++ b/src/components/homepage/HeroSection.tsx
@@ -203,7 +203,7 @@ const MockBillCard = ({ stage }: { stage: number }) => {
                   <motion.div
                     animate={{ scale: [1, 1.15, 1] }}
                     transition={{ repeat: Infinity, duration: 0.9, ease: "easeInOut" }}
-                    className="w-14 h-14 rounded-2xl bg-white/90 flex items-center justify-center shadow-lg"
+                    className="w-14 h-14 rounded-md bg-white/90 flex items-center justify-center shadow-lg"
                   >
                     <Camera className="w-7 h-7 text-primary" />
                   </motion.div>

--- a/src/components/homepage/HeroSection.tsx
+++ b/src/components/homepage/HeroSection.tsx
@@ -57,7 +57,9 @@ const SETTLEMENT = { from: "Andi", to: "Budi", amount: "Rp 300.000" };
 // Items that "pop in" one by one while the scan-line sweeps — makes the AI parsing feel active, not just a bare progress bar
 const SCAN_FINDINGS = ["8 menu", "Pajak", "Service"];
 
-const STAGE_DURATIONS = [1600, 1800, 1300, 3800]; // capture -> scanning -> done -> result
+// Kept short — Lighthouse Speed Index counts every pixel change until the page settles,
+// so a slow multi-second reveal directly tanks SI even though FCP/LCP land fine.
+const STAGE_DURATIONS = [500, 1600, 500, 3800]; // capture -> scanning -> done -> result (last unused, reveal stops the loop)
 
 // Same card frame throughout — only the content inside swaps (skeleton -> overlay -> real numbers)
 // Content mirrors the real split-bill detail summary (header stats + settlement + per-person status), simplified for a compact hero mockup.
@@ -293,7 +295,7 @@ const ScanFlow = () => {
             scale: revealed ? 1 : 0.8,
           }}
           transition={{
-            y: { repeat: Infinity, duration: 2.8, ease: "easeInOut" },
+            y: { repeat: 2, duration: 2.8, ease: "easeInOut" },
             opacity: { duration: 0.25, delay: revealed ? 0.1 : 0 },
             scale: { type: "spring", stiffness: 350, damping: 16, delay: revealed ? 0.1 : 0 },
           }}
@@ -311,7 +313,7 @@ const ScanFlow = () => {
             scale: revealed ? 1 : 0.8,
           }}
           transition={{
-            y: { repeat: Infinity, duration: 3, ease: "easeInOut" },
+            y: { repeat: 2, duration: 3, ease: "easeInOut" },
             opacity: { duration: 0.25, delay: revealed ? 0.45 : 0 },
             scale: { type: "spring", stiffness: 350, damping: 16, delay: revealed ? 0.45 : 0 },
           }}
@@ -336,21 +338,23 @@ export const HeroSection = () => {
       {/* Soft top spotlight — depth without a heavy corner gradient */}
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_80%_50%_at_50%_-10%,rgba(71,159,234,0.16),transparent)]" />
 
-      {/* Aurora blobs — layered, slowly drifting, more alive than a flat wash */}
+      {/* Aurora blobs — single settle-in pass, not infinite. An endless loop never lets
+          Lighthouse consider the page "visually stable," which tanks Speed Index even
+          after real content has painted. */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
         <motion.div
           animate={{ scale: [1, 1.12, 1], x: [0, 24, 0], y: [0, -18, 0], opacity: [0.28, 0.42, 0.28] }}
-          transition={{ repeat: Infinity, duration: 9, ease: "easeInOut" }}
+          transition={{ repeat: 1, duration: 2.5, ease: "easeInOut" }}
           className="absolute top-[-15%] right-[-8%] w-[50vw] h-[50vw] max-w-[700px] max-h-[700px] rounded-full bg-primary/25 blur-[100px]"
         />
         <motion.div
           animate={{ scale: [1, 1.15, 1], x: [0, -22, 0], y: [0, 18, 0], opacity: [0.18, 0.32, 0.18] }}
-          transition={{ repeat: Infinity, duration: 11, ease: "easeInOut", delay: 1.5 }}
+          transition={{ repeat: 1, duration: 2.5, ease: "easeInOut", delay: 0.3 }}
           className="absolute bottom-[-15%] left-[-10%] w-[45vw] h-[45vw] max-w-[600px] max-h-[600px] rounded-full bg-sky-300/25 blur-[90px]"
         />
         <motion.div
           animate={{ scale: [1, 1.1, 1], opacity: [0.15, 0.28, 0.15] }}
-          transition={{ repeat: Infinity, duration: 7, ease: "easeInOut", delay: 3 }}
+          transition={{ repeat: 1, duration: 2.5, ease: "easeInOut", delay: 0.6 }}
           className="absolute top-[18%] right-[8%] w-[25vw] h-[25vw] max-w-[350px] max-h-[350px] rounded-full bg-emerald-300/20 blur-[80px]"
         />
       </div>
@@ -525,8 +529,6 @@ export const HeroSection = () => {
                   height={720}
                   sizes="(max-width: 640px) 280px, 560px"
                   className="object-contain w-full h-auto"
-                  priority
-                  fetchPriority="high"
                 />
               </div>
 

--- a/src/components/homepage/HomepageAIScanCard.tsx
+++ b/src/components/homepage/HomepageAIScanCard.tsx
@@ -15,7 +15,7 @@ export const HomepageAIScanCard = () => {
   const isExhausted = !isSubscribed && freeScanCount <= 0;
 
   return (
-    <div className="relative p-[1.5px] rounded-2xl bg-gradient-to-br from-violet-400 via-pink-400 to-primary shadow-lg shadow-pink-500/5 transition-all duration-300 h-full w-full flex flex-col group/card hover:scale-[1.005] active:scale-[0.99] overflow-hidden">
+    <div className="relative p-[1.5px] rounded-md bg-gradient-to-br from-violet-400 via-pink-400 to-primary shadow-lg shadow-pink-500/5 transition-all duration-300 h-full w-full flex flex-col group/card hover:scale-[1.005] active:scale-[0.99] overflow-hidden">
       {/* Stick Badge */}
       <div className={cn(
         "absolute top-0 right-0 px-3 py-1.5 rounded-bl-md flex items-center gap-1 text-[9px] font-black uppercase z-30 shadow-md transition-transform group-hover/card:scale-105 origin-top-right",
@@ -27,7 +27,7 @@ export const HomepageAIScanCard = () => {
         <span>{isSubscribed ? "PRO" : "Free"}</span>
       </div>
 
-      <div className="relative overflow-hidden bg-white rounded-[calc(1rem-1.5px)] z-10 flex-grow flex flex-col justify-between p-6">
+      <div className="relative overflow-hidden bg-white rounded-[calc(var(--radius-md)-1.5px)] z-10 flex-grow flex flex-col justify-between p-6">
         {/* Subtle background glow */}
         <div className="absolute top-0 right-0 w-24 h-24 bg-pink-500/5 rounded-full blur-2xl -mr-6 -mt-6 pointer-events-none" />
 

--- a/src/components/homepage/HomepagePageClient.tsx
+++ b/src/components/homepage/HomepagePageClient.tsx
@@ -49,23 +49,36 @@ const CTABannerSection = dynamic(
 );
 const HomepagePromoSlider = dynamic(
   () => import("./HomepagePromoSlider").then((mod) => mod.HomepagePromoSlider),
-  { ssr: true }
+  { ssr: true, loading: sectionSkeleton(320) }
 );
+// loading: () => null — no fallback UI needed, but required so next/dynamic wraps
+// its own local Suspense instead of suspending to the root app/loading.tsx and
+// blanking the whole page while the chunk fetches (same bug as HomepagePromoSlider).
 const ChatAgentFAB = dynamic(
   () => import("@/components/splitbill/chat/ChatAgentFAB").then((mod) => mod.ChatAgentFAB),
-  { ssr: false }
+  { ssr: false, loading: () => null }
 );
 const ChatRoom = dynamic(
   () => import("@/components/splitbill/chat/ChatRoom").then((mod) => mod.ChatRoom),
-  { ssr: false }
+  { ssr: false, loading: () => null }
 );
 
 export const HomepagePageClient = () => {
   const { isAuthenticated } = useAuthStore();
   const [isMounted, setIsMounted] = useState(false);
+  const [isChatReady, setIsChatReady] = useState(false);
 
   useEffect(() => {
     setIsMounted(true);
+
+    // Chat widget isn't needed for first paint — load it once the browser is idle
+    // instead of racing the hero's own hydration/animation work.
+    if ("requestIdleCallback" in window) {
+      const id = window.requestIdleCallback(() => setIsChatReady(true), { timeout: 3000 });
+      return () => window.cancelIdleCallback(id);
+    }
+    const t = setTimeout(() => setIsChatReady(true), 2000);
+    return () => clearTimeout(t);
   }, []);
 
   return (
@@ -178,9 +191,9 @@ export const HomepagePageClient = () => {
       {/* Site Footer */}
       <HomepageFooter />
 
-      {/* Chat Agent FAB */}
-      {isMounted && <ChatAgentFAB bottomClass="bottom-6" />}
-      {isMounted && <ChatRoom />}
+      {/* Chat Agent FAB — deferred to idle, not needed for first paint */}
+      {isChatReady && <ChatAgentFAB bottomClass="bottom-6" />}
+      {isChatReady && <ChatRoom />}
     </div>
   );
 };

--- a/src/components/homepage/HomepagePromoSlider.tsx
+++ b/src/components/homepage/HomepagePromoSlider.tsx
@@ -7,12 +7,15 @@ import Image from "next/image";
 import { useAuthStore } from "@/lib/stores/authStore";
 import { ChevronLeft, ChevronRight, Sparkles } from "lucide-react";
 
+// loading: () => null — same reasoning as ChatAgentFAB in HomepagePageClient:
+// without it, next/dynamic suspends to the root app/loading.tsx instead of
+// failing locally, blanking the whole page while this chunk fetches.
 const HomepageAIScanCard = dynamic(
   () =>
     import("./HomepageAIScanCard").then(
       (mod) => mod.HomepageAIScanCard,
     ),
-  { ssr: false },
+  { ssr: false, loading: () => null },
 );
 
 export const HomepagePromoSlider = () => {

--- a/src/components/homepage/HomepagePromoSlider.tsx
+++ b/src/components/homepage/HomepagePromoSlider.tsx
@@ -72,14 +72,14 @@ export const HomepagePromoSlider = () => {
             {/* Card 2: Split Later Feature */}
             <div className="flex-shrink-0 w-[85vw] sm:w-[480px] snap-start h-auto flex">
               <Link href="/split-later" className="block w-full h-full group/card transition-all duration-300 hover:scale-[1.005] active:scale-[0.99]">
-                <div className="relative p-[1.5px] rounded-2xl bg-gradient-to-br from-blue-400 via-blue-500 to-primary shadow-lg shadow-primary/5 h-full flex flex-col overflow-hidden">
+                <div className="relative p-[1.5px] rounded-md bg-gradient-to-br from-blue-400 via-blue-500 to-primary shadow-lg shadow-primary/5 h-full flex flex-col overflow-hidden">
                   {/* Stick Badge - Primary Blue Style */}
                   <div className="absolute top-0 right-0 px-3 py-1.5 rounded-bl-xl flex items-center gap-1.5 text-[9px] font-black uppercase bg-primary text-white z-30 shadow-md transition-transform group-hover/card:scale-105 origin-top-right">
                     <span className="w-1.5 h-1.5 rounded-full bg-white animate-pulse" />
                     <span>NEW</span>
                   </div>
 
-                  <div className="bg-white rounded-[calc(1rem-1.5px)] p-6 flex-grow flex flex-col justify-between relative overflow-hidden">
+                  <div className="bg-white rounded-[calc(var(--radius-md)-1.5px)] p-6 flex-grow flex flex-col justify-between relative overflow-hidden">
                     <div className="absolute top-0 right-0 w-24 h-24 bg-primary/5 rounded-full blur-2xl -mr-6 -mt-6 pointer-events-none" />
 
                     <div className="flex items-center gap-4">
@@ -114,14 +114,14 @@ export const HomepagePromoSlider = () => {
             {/* Card 3: Review Rewards */}
             <div className="flex-shrink-0 w-[85vw] sm:w-[480px] snap-start h-auto flex">
               <Link href="/review" className="block w-full h-full group/card transition-all duration-300 hover:scale-[1.005] active:scale-[0.99]">
-                <div className="relative p-[1.5px] rounded-2xl bg-gradient-to-br from-amber-200 via-orange-300 to-yellow-200 shadow-lg shadow-amber-200/5 h-full flex flex-col overflow-hidden">
+                <div className="relative p-[1.5px] rounded-md bg-gradient-to-br from-amber-200 via-orange-300 to-yellow-200 shadow-lg shadow-amber-200/5 h-full flex flex-col overflow-hidden">
                   {/* Stick Badge - Pastel Orange Style */}
                   <div className="absolute top-0 right-0 px-3 py-1.5 rounded-bl-xl flex items-center gap-1.5 text-[9px] font-black uppercase bg-orange-400 text-white z-30 shadow-md transition-transform group-hover/card:scale-105 origin-top-right">
                     <Sparkles className="w-3 h-3 fill-current" />
                     <span>REWARDS</span>
                   </div>
 
-                  <div className="bg-white rounded-[calc(1rem-1.5px)] p-6 flex-grow flex flex-col justify-between relative overflow-hidden">
+                  <div className="bg-white rounded-[calc(var(--radius-md)-1.5px)] p-6 flex-grow flex flex-col justify-between relative overflow-hidden">
                     <div className="absolute top-0 right-0 w-24 h-24 bg-orange-500/5 rounded-full blur-2xl -mr-6 -mt-6 pointer-events-none" />
 
                     <div className="flex items-center gap-4">

--- a/src/components/homepage/HowItWorksSection.tsx
+++ b/src/components/homepage/HowItWorksSection.tsx
@@ -113,7 +113,7 @@ export const HowItWorksSection = () => {
                     className="flex-shrink-0 w-[82vw] snap-center flex flex-col items-center text-center"
                   >
                     {/* Image */}
-                    <div className="relative w-full max-w-[260px] aspect-square rounded-3xl overflow-hidden mb-6">
+                    <div className="relative w-full max-w-[260px] aspect-square rounded-xl overflow-hidden mb-6">
                       <Image
                         src={step.image}
                         alt={step.title}

--- a/src/components/homepage/PricingSection.tsx
+++ b/src/components/homepage/PricingSection.tsx
@@ -58,7 +58,7 @@ export const PricingSection = () => {
         </div>
 
         {/* Pricing Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-4xl mx-auto items-stretch">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 lg:gap-8 max-w-4xl mx-auto items-stretch">
           {/* Free Card */}
           <motion.div
             initial={{ opacity: 0, y: 30 }}
@@ -132,7 +132,7 @@ export const PricingSection = () => {
                 </h3>
                 <div className="flex items-baseline gap-1">
                   <span className="text-4xl sm:text-5xl font-black text-white">
-                    Rp 15K
+                    Rp 9K
                   </span>
                   <span className="text-violet-200 font-semibold text-sm">
                     / bulan

--- a/src/components/homepage/TestimonialsSection.tsx
+++ b/src/components/homepage/TestimonialsSection.tsx
@@ -7,7 +7,7 @@ import { useReview, Review } from "@/hooks/useReview";
 
 // Skeleton card for loading state
 const SkeletonCard = () => (
-  <div className="flex-shrink-0 w-[290px] sm:w-[360px] bg-white rounded-2xl p-6 border border-slate-100/80 shadow-[0_4px_20px_-4px_rgba(71,159,234,0.08)] space-y-4">
+  <div className="flex-shrink-0 w-[290px] sm:w-[360px] bg-white rounded-md p-6 border border-slate-100/80 shadow-[0_4px_20px_-4px_rgba(71,159,234,0.08)] space-y-4">
     <div className="flex gap-1">
       {[0, 1, 2, 3, 4].map((s) => (
         <div key={s} className="h-3.5 w-3.5 rounded-sm bg-slate-100 animate-pulse" />

--- a/src/components/onboarding/TutorialOverlay.tsx
+++ b/src/components/onboarding/TutorialOverlay.tsx
@@ -111,7 +111,7 @@ export const TutorialOverlay = ({
       )}>
         {spotlightRect && (
           <div
-            className="absolute bg-transparent shadow-[0_0_0_9999px_rgba(0,0,0,0.6)] rounded-2xl transition-all duration-500 ease-in-out"
+            className="absolute bg-transparent shadow-[0_0_0_9999px_rgba(0,0,0,0.6)] rounded-md transition-all duration-500 ease-in-out"
             style={{
               top: spotlightRect.top,
               left: spotlightRect.left,
@@ -131,7 +131,7 @@ export const TutorialOverlay = ({
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.9, y: -20 }}
             className={cn(
-              "absolute pointer-events-auto w-full max-w-[280px] bg-white rounded-2xl p-4 shadow-2xl flex flex-col gap-2 border border-white/20",
+              "absolute pointer-events-auto w-full max-w-[280px] bg-white rounded-md p-4 shadow-2xl flex flex-col gap-2 border border-white/20",
               !spotlightRect && "static",
               spotlightRect && currentStep.position === "bottom" && "top-[calc(var(--top)+var(--height)+20px)]",
               spotlightRect && currentStep.position === "top" && "bottom-[calc(100%-var(--top)+20px)]"
@@ -163,14 +163,14 @@ export const TutorialOverlay = ({
                 <Button
                   variant="outline"
                   onClick={handleBack}
-                  className="flex-1 rounded-md h-10 text-xs"
+                  className="flex-1 rounded-sm h-10 text-xs"
                 >
                   <ChevronLeft className="w-3 h-3 mr-1" /> Balik
                 </Button>
               )}
               <Button
                 onClick={handleNext}
-                className="flex-2 rounded-md h-10 font-bold text-xs"
+                className="flex-2 rounded-xs h-10 font-bold text-xs"
               >
                 {currentStepIndex === steps.length - 1 ? (
                   <>Mulai! <Rocket className="w-3 h-3 ml-1" /></>

--- a/src/components/onboarding/TutorialOverlay.tsx
+++ b/src/components/onboarding/TutorialOverlay.tsx
@@ -40,10 +40,23 @@ export const TutorialOverlay = ({
 
   const currentStep = steps[currentStepIndex];
 
-  const updateSpotlight = useCallback(() => {
+  const recalculateSpotlight = useCallback(() => {
+    if (!isOpen || !currentStep) return;
+    const element = document.getElementById(currentStep.targetId);
+    if (!element) return;
+    const rect = element.getBoundingClientRect();
+    setSpotlightRect({
+      top: rect.top - 8,
+      left: rect.left - 8,
+      width: rect.width + 16,
+      height: rect.height + 16,
+    });
+  }, [isOpen, currentStep]);
+
+  const scrollToTarget = useCallback(() => {
     if (!isOpen || !currentStep) return;
 
-    const findAndSetSpotlight = (retryCount = 0) => {
+    const findAndScroll = (retryCount = 0) => {
       const element = document.getElementById(currentStep.targetId);
       if (element) {
         const rect = element.getBoundingClientRect();
@@ -53,32 +66,31 @@ export const TutorialOverlay = ({
           width: rect.width + 16,
           height: rect.height + 16,
         });
-        
-        // Scroll to element if not in view
+
         element.scrollIntoView({ behavior: "smooth", block: "center" });
       } else if (retryCount < 5) {
         // Retry if element not found yet (e.g., during page transition)
-        setTimeout(() => findAndSetSpotlight(retryCount + 1), 100);
+        setTimeout(() => findAndScroll(retryCount + 1), 100);
       } else {
         // If element still not found, show in center
         setSpotlightRect(null);
       }
     };
 
-    findAndSetSpotlight();
+    findAndScroll();
   }, [isOpen, currentStep]);
 
   useEffect(() => {
     if (isOpen) {
-      updateSpotlight();
-      window.addEventListener("resize", updateSpotlight);
-      window.addEventListener("scroll", updateSpotlight);
+      scrollToTarget();
+      window.addEventListener("resize", recalculateSpotlight);
+      window.addEventListener("scroll", recalculateSpotlight);
     }
     return () => {
-      window.removeEventListener("resize", updateSpotlight);
-      window.removeEventListener("scroll", updateSpotlight);
+      window.removeEventListener("resize", recalculateSpotlight);
+      window.removeEventListener("scroll", recalculateSpotlight);
     };
-  }, [isOpen, updateSpotlight]);
+  }, [isOpen, scrollToTarget, recalculateSpotlight]);
 
   const handleNext = () => {
     if (currentStepIndex < steps.length - 1) {

--- a/src/components/payment/PaymentForm.tsx
+++ b/src/components/payment/PaymentForm.tsx
@@ -76,7 +76,7 @@ export default function PaymentForm({ onSuccess }: PaymentFormProps) {
               <Input
                 id="name"
                 placeholder="Contoh: Agus"
-                className="pl-12 h-14 bg-white border-border/60 hover:border-primary/40 focus-visible:border-primary/60 focus-visible:ring-primary/5 transition-all rounded-2xl font-medium"
+                className="pl-12 h-14 bg-white border-border/60 hover:border-primary/40 focus-visible:border-primary/60 focus-visible:ring-primary/5 transition-all rounded-md font-medium"
                 value={formData.name}
                 onChange={handleChange}
                 required
@@ -94,7 +94,7 @@ export default function PaymentForm({ onSuccess }: PaymentFormProps) {
                 id="phone"
                 type="tel"
                 placeholder="08123456789"
-                className="pl-12 h-14 bg-white border-border/60 hover:border-primary/40 focus-visible:border-primary/60 focus-visible:ring-primary/5 transition-all rounded-2xl font-medium"
+                className="pl-12 h-14 bg-white border-border/60 hover:border-primary/40 focus-visible:border-primary/60 focus-visible:ring-primary/5 transition-all rounded-md font-medium"
                 value={formData.phone}
                 onChange={handleChange}
                 required
@@ -112,7 +112,7 @@ export default function PaymentForm({ onSuccess }: PaymentFormProps) {
                 id="amount"
                 type="number"
                 placeholder="0"
-                className="pl-12 h-14 bg-white border-border/60 hover:border-primary/40 focus-visible:border-primary/60 focus-visible:ring-primary/5 transition-all rounded-2xl font-bold text-lg"
+                className="pl-12 h-14 bg-white border-border/60 hover:border-primary/40 focus-visible:border-primary/60 focus-visible:ring-primary/5 transition-all rounded-md font-bold text-lg"
                 value={formData.amount}
                 onChange={handleChange}
                 required
@@ -120,9 +120,9 @@ export default function PaymentForm({ onSuccess }: PaymentFormProps) {
             </div>
           </div>
 
-          <Button 
-            type="submit" 
-            className="w-full h-14 text-lg font-bold hover:scale-[1.01] active:scale-95 transition-all rounded-2xl mt-2" 
+          <Button
+            type="submit"
+            className="w-full h-14 text-lg font-bold hover:scale-[1.01] active:scale-95 transition-all rounded-md mt-2"
             disabled={loading}
           >
             {loading ? (

--- a/src/components/payment/QRCodeDisplay.tsx
+++ b/src/components/payment/QRCodeDisplay.tsx
@@ -44,23 +44,23 @@ export default function QRCodeDisplay({ paymentUrl }: QRCodeDisplayProps) {
   return (
     <div className="w-full flex flex-col items-center space-y-6">
       <div className="bg-white p-6 rounded-xl border border-slate-100 flex items-center justify-center transition-transform hover:scale-[1.02] duration-500">
-        <QRCodeSVG 
-          value={paymentUrl} 
-          size={220} 
-          level="H" 
-          includeMargin 
+        <QRCodeSVG
+          value={paymentUrl}
+          size={220}
+          level="H"
+          includeMargin
           className="rounded-xl"
         />
       </div>
-      
+
       <div className="w-full space-y-3">
         <div className="relative group">
-          <Input 
-            value={paymentUrl} 
-            readOnly 
-            className="bg-slate-50 border-slate-200 h-14 rounded-2xl pr-12 text-xs font-medium text-slate-500 truncate focus:ring-primary/20 transition-all font-medium" 
+          <Input
+            value={paymentUrl}
+            readOnly
+            className="bg-slate-50 border-slate-200 h-14 rounded-md pr-12 text-xs font-medium text-slate-500 truncate focus:ring-primary/20 transition-all font-medium"
           />
-          <button 
+          <button
             type="button"
             className="absolute right-2 top-1/2 -translate-y-1/2 p-2 text-slate-400 hover:text-primary hover:bg-white rounded-xl transition-all active:scale-90 cursor-pointer"
             onClick={copyToClipboard}
@@ -69,9 +69,9 @@ export default function QRCodeDisplay({ paymentUrl }: QRCodeDisplayProps) {
           </button>
         </div>
 
-        <Button 
-          onClick={shareLink} 
-          className="w-full h-14 text-lg font-bold hover:scale-[1.01] active:scale-95 transition-all rounded-2xl"
+        <Button
+          onClick={shareLink}
+          className="w-full h-14 text-lg font-bold hover:scale-[1.01] active:scale-95 transition-all rounded-md"
         >
           <Share2 className="mr-2 h-5 w-5" />
           Bagikan Link Pembayaran

--- a/src/components/payment/WalletButtons.tsx
+++ b/src/components/payment/WalletButtons.tsx
@@ -48,11 +48,11 @@ export default function WalletButtons({ phone, amount }: WalletButtonsProps) {
         >
           <div className="flex items-center gap-3">
             <div className="w-12 h-12 flex items-center justify-center bg-slate-50 rounded-xl group-hover:bg-[#00AA13]/5 transition-colors">
-              <Image 
-                src="/img/logo-gopay.png" 
-                alt="GoPay" 
-                width={32} 
-                height={32} 
+              <Image
+                src="/img/logo-gopay.png"
+                alt="GoPay"
+                width={32}
+                height={32}
                 className="object-contain"
               />
             </div>
@@ -71,11 +71,11 @@ export default function WalletButtons({ phone, amount }: WalletButtonsProps) {
         >
           <div className="flex items-center gap-3">
             <div className="w-12 h-12 flex items-center justify-center bg-slate-50 rounded-xl group-hover:bg-[#118EEA]/5 transition-colors">
-              <Image 
-                src="/img/logo-dana.png" 
-                alt="DANA" 
-                width={32} 
-                height={32} 
+              <Image
+                src="/img/logo-dana.png"
+                alt="DANA"
+                width={32}
+                height={32}
                 className="object-contain"
               />
             </div>
@@ -94,11 +94,11 @@ export default function WalletButtons({ phone, amount }: WalletButtonsProps) {
         >
           <div className="flex items-center gap-3">
             <div className="w-12 h-12 flex items-center justify-center bg-slate-50 rounded-xl group-hover:bg-[#EE4D2D]/5 transition-colors">
-              <Image 
-                src="/img/logo-shopeepay.png" 
-                alt="ShopeePay" 
-                width={32} 
-                height={32} 
+              <Image
+                src="/img/logo-shopeepay.png"
+                alt="ShopeePay"
+                width={32}
+                height={32}
                 className="object-contain"
               />
             </div>
@@ -120,9 +120,9 @@ export default function WalletButtons({ phone, amount }: WalletButtonsProps) {
         </div>
       </div>
 
-      <Button 
-        variant="secondary" 
-        className="w-full h-14 text-base font-bold rounded-2xl transition-all active:scale-[0.98]"
+      <Button
+        variant="secondary"
+        className="w-full h-14 text-base font-bold rounded-md transition-all active:scale-[0.98]"
         onClick={copyPhone}
       >
         <Copy className="mr-2 h-5 w-5" />

--- a/src/components/profile/friends/FriendForm.tsx
+++ b/src/components/profile/friends/FriendForm.tsx
@@ -141,7 +141,7 @@ export const FriendForm = ({
           />
         </div>
 
-        <div className="p-4 bg-primary/5 rounded-2xl border border-primary/10">
+        <div className="p-4 bg-primary/5 rounded-md border border-primary/10">
           <p className="text-[11px] leading-relaxed text-slate-600">
             💡 <b>Tips:</b> Dengan menyimpan daftar teman, kamu bisa lebih cepat memilih orang saat sedang bagi tagihan.
           </p>

--- a/src/components/review/ReviewForm.tsx
+++ b/src/components/review/ReviewForm.tsx
@@ -176,7 +176,7 @@ export function ReviewForm() {
               Ulasan & Feedback
             </label>
             <textarea
-              className="w-full min-h-[120px] rounded-2xl border border-foreground/10 bg-white px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all resize-none"
+              className="w-full min-h-[120px] rounded-md border border-foreground/10 bg-white px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all resize-none"
               placeholder="Tuliskan ulasan dan feedback kamu di sini..."
               value={review}
               onChange={(e) => setReview(e.target.value)}
@@ -264,7 +264,7 @@ export function ReviewForm() {
           <div className="bg-background px-4 pb-4 flex flex-col gap-3">
             <Button
               type="submit"
-              className="w-full h-14 rounded-2xl text-lg font-bold shadow-xl shadow-primary/20 bg-primary text-white transition-all active:scale-95"
+              className="w-full h-14 rounded-md text-lg font-bold shadow-xl shadow-primary/20 bg-primary text-white transition-all active:scale-95"
               disabled={isSubmitting || isInCooldown}
               loading={isSubmitting}
             >

--- a/src/components/split-later/BucketCard.tsx
+++ b/src/components/split-later/BucketCard.tsx
@@ -46,7 +46,7 @@ export const BucketCard = ({ bucket, stats, onClick }: BucketCardProps) => {
         <div className="flex items-start justify-between gap-3">
           <div className="flex items-center gap-3 min-w-0">
             {/* Emoji icon */}
-            <div className="w-12 h-12 rounded-2xl bg-primary/5 border border-primary/10 flex items-center justify-center text-2xl shrink-0 group-hover:scale-110 transition-transform duration-300">
+            <div className="w-12 h-12 rounded-md bg-primary/5 border border-primary/10 flex items-center justify-center text-2xl shrink-0 group-hover:scale-110 transition-transform duration-300">
               {bucket.emoji}
             </div>
 

--- a/src/components/split-later/BucketFormBottomSheet.tsx
+++ b/src/components/split-later/BucketFormBottomSheet.tsx
@@ -28,16 +28,16 @@ const BUCKET_TYPE_OPTIONS: {
   label: string;
   emoji: string;
 }[] = [
-  { value: "trip", label: "Liburan / Traveling", emoji: "✈️" },
-  { value: "hangout", label: "Makan / Nongkrong", emoji: "🍜" },
-  { value: "event", label: "Pesta / Konser / Event", emoji: "🎉" },
-  { value: "office", label: "Kantor / Work Trip", emoji: "💼" },
-  { value: "household", label: "Belanja / Sembako", emoji: "🏠" },
-  { value: "event", label: "Arisan / Gathering", emoji: "🎈" },
-  { value: "other", label: "Olahraga / Workout", emoji: "⚽" },
-  { value: "other", label: "Kado / Ulang Tahun", emoji: "🎁" },
-  { value: "other", label: "Lainnya", emoji: "📦" },
-];
+    { value: "trip", label: "Liburan / Traveling", emoji: "✈️" },
+    { value: "hangout", label: "Makan / Nongkrong", emoji: "🍜" },
+    { value: "event", label: "Pesta / Konser / Event", emoji: "🎉" },
+    { value: "office", label: "Kantor / Work Trip", emoji: "💼" },
+    { value: "household", label: "Belanja / Sembako", emoji: "🏠" },
+    { value: "event", label: "Arisan / Gathering", emoji: "🎈" },
+    { value: "other", label: "Olahraga / Workout", emoji: "⚽" },
+    { value: "other", label: "Kado / Ulang Tahun", emoji: "🎁" },
+    { value: "other", label: "Lainnya", emoji: "📦" },
+  ];
 
 const EMOJI_OPTIONS = [
   "✈️",
@@ -192,7 +192,7 @@ export const BucketFormBottomSheet = ({
 
       <div
         className={cn(
-          "absolute bottom-0 w-full max-w-[600px] bg-white rounded-t-3xl shadow-2xl overflow-hidden flex flex-col max-h-[80dvh]",
+          "absolute bottom-0 w-full max-w-[600px] bg-white rounded-t-md shadow-2xl overflow-hidden flex flex-col max-h-[80dvh]",
           "animate-in slide-in-from-bottom-full duration-300 ease-out",
         )}
       >
@@ -272,7 +272,7 @@ export const BucketFormBottomSheet = ({
                     setEmoji(opt.emoji);
                   }}
                   className={cn(
-                    "flex flex-col items-center gap-1 py-3 px-2 rounded-2xl text-xs font-bold transition-all active:scale-95 cursor-pointer border border-primary/5 ",
+                    "flex flex-col items-center gap-1 py-3 px-2 rounded-md text-xs font-bold transition-all active:scale-95 cursor-pointer border border-primary/5 ",
                     selectedCategoryLabel === opt.label
                       ? "bg-primary text-white border-primary shadow-md shadow-primary/20"
                       : "bg-muted/30 text-muted-foreground hover:bg-primary/5 hover:text-primary",

--- a/src/components/split-later/BucketSettlement.tsx
+++ b/src/components/split-later/BucketSettlement.tsx
@@ -379,7 +379,7 @@ export const BucketSettlement = ({
         icon={TrendingUp}
         message="Belum Ada Struk yang Diproses"
         subtitle="Proses struk-struk di tab Struk dulu ya, nanti hasilnya bakal muncul di sini."
-        className="bg-white/50 rounded-2xl"
+        className="bg-white/50 rounded-md"
       />
     );
   }
@@ -387,7 +387,7 @@ export const BucketSettlement = ({
   return (
     <div className="space-y-4">
       {/* Encourage to Share Card (SaveBillNudge style) */}
-      <Card className="border border-primary/20 shadow-soft bg-primary/5 overflow-hidden rounded-2xl">
+      <Card className="border border-primary/20 shadow-soft bg-primary/5 overflow-hidden rounded-md">
         <CardContent className="p-5 space-y-4">
           <div className="flex items-start gap-4">
             <div className="w-10 h-10 rounded-xl relative overflow-hidden shrink-0">

--- a/src/components/split-later/ReceiptCard.tsx
+++ b/src/components/split-later/ReceiptCard.tsx
@@ -17,7 +17,7 @@ export const ReceiptCard = ({ receipt, onProcess, onDelete }: ReceiptCardProps) 
   const isPending = receipt.status === "pending";
 
   return (
-    <div className="relative group rounded-2xl overflow-hidden bg-white shadow-soft border border-primary/5 hover:shadow-md transition-all duration-300">
+    <div className="relative group rounded-md overflow-hidden bg-white shadow-soft border border-primary/5 hover:shadow-md transition-all duration-300">
       {/* Receipt image */}
       <div className="aspect-[3/4] w-full overflow-hidden bg-muted/30">
         <img

--- a/src/components/split-later/ReceiptGrid.tsx
+++ b/src/components/split-later/ReceiptGrid.tsx
@@ -54,7 +54,7 @@ export const ReceiptGrid = ({
           icon={Camera}
           message="Belum Ada Struk"
           subtitle="Yuk foto struk pertamamu! Bisa ambil foto langsung atau upload dari galeri."
-          className="bg-white/50 rounded-2xl"
+          className="bg-white/50 rounded-md"
         />
       ) : (
         <div className="grid grid-cols-2 gap-3 pt-4">

--- a/src/components/split-later/SocialSplitLaterReceipt.tsx
+++ b/src/components/split-later/SocialSplitLaterReceipt.tsx
@@ -105,7 +105,7 @@ export const SocialSplitLaterReceipt = React.forwardRef<
       {/* Branding */}
       <div className="relative z-10 w-full flex justify-between items-center mb-8">
         <div className="flex items-center gap-5">
-          <div className="w-20 h-20 bg-white rounded-2xl flex items-center justify-center border border-primary/5 relative overflow-hidden">
+          <div className="w-20 h-20 bg-white rounded-md flex items-center justify-center border border-primary/5 relative overflow-hidden">
             <img
               src="/img/footer-icon.png"
               alt="SplitBill Logo"
@@ -348,7 +348,7 @@ export const SocialSplitLaterReceipt = React.forwardRef<
                   key={method.id}
                   className="p-6 bg-white border border-slate-100 rounded-[35px] flex items-center gap-8"
                 >
-                  <div className="w-24 h-24 bg-slate-50 rounded-3xl flex items-center justify-center border border-slate-100 shrink-0 relative overflow-hidden">
+                  <div className="w-24 h-24 bg-slate-50 rounded-md flex items-center justify-center border border-slate-100 shrink-0 relative overflow-hidden">
                     {[
                       "bca",
                       "bni",

--- a/src/components/splitbill/ReviewBanner.tsx
+++ b/src/components/splitbill/ReviewBanner.tsx
@@ -12,7 +12,7 @@ interface ReviewBannerProps {
 
 export const ReviewBanner: React.FC<ReviewBannerProps> = ({ onClose }) => {
   const router = useRouter();
-   const [isVisible, setIsVisible] = useState(true);
+  const [isVisible, setIsVisible] = useState(true);
   const { user, isAuthenticated } = useAuthStore();
 
   const showRewardCopy = !isAuthenticated || (isAuthenticated && !user?.hasClaimedReviewReward);
@@ -47,7 +47,7 @@ export const ReviewBanner: React.FC<ReviewBannerProps> = ({ onClose }) => {
           trackGeneral.reviewBannerClick();
           router.push("/review");
         }}
-        className="bg-primary text-primary-foreground rounded-2xl p-4 shadow-xl flex items-center justify-between cursor-pointer relative overflow-hidden group max-w-[600px] mx-auto pointer-events-auto"
+        className="bg-primary text-primary-foreground rounded-md p-4 shadow-xl flex items-center justify-between cursor-pointer relative overflow-hidden group max-w-[600px] mx-auto pointer-events-auto"
       >
         {/* Background elements for visual interest */}
         <div className="absolute top-0 right-0 p-8 bg-white/10 rounded-full -mr-4 -mt-4 blur-xl"></div>
@@ -62,8 +62,8 @@ export const ReviewBanner: React.FC<ReviewBannerProps> = ({ onClose }) => {
               {showRewardCopy ? "Bonus +5 Kuota Scan AI 🎁" : "Suka aplikasinya?"}
             </h4>
             <p className="text-xs text-primary-foreground/80">
-              {showRewardCopy 
-                ? "Kirim review pertama kamu sekarang!" 
+              {showRewardCopy
+                ? "Kirim review pertama kamu sekarang!"
                 : "Bantu kami kasih rating bintang 5 ya! ⭐"}
             </p>
           </div>

--- a/src/components/splitbill/SocialReceiptPreviewBanner.tsx
+++ b/src/components/splitbill/SocialReceiptPreviewBanner.tsx
@@ -65,7 +65,7 @@ export const SocialReceiptPreviewBanner = ({
   const visibleReceiptHeight = scale > 0 ? PREVIEW_HEIGHT / scale : 0;
 
   return (
-    <div className="rounded-2xl overflow-hidden bg-white shadow-[0_8px_32px_rgba(0,0,0,0.05)]">
+    <div className="rounded-md overflow-hidden bg-white shadow-[0_8px_32px_rgba(0,0,0,0.05)]">
       {/* Measurement anchor + scaled receipt */}
       <div
         ref={containerRef}

--- a/src/components/splitbill/SocialSplitBillReceipt.tsx
+++ b/src/components/splitbill/SocialSplitBillReceipt.tsx
@@ -93,7 +93,7 @@ export const SocialSplitBillReceipt = React.forwardRef<
       {/* Branding */}
       <div className="relative z-10 w-full flex justify-between items-center mb-6">
         <div className="flex items-center gap-5">
-          <div className="w-20 h-20 bg-white rounded-2xl flex items-center justify-center border border-primary/5 relative overflow-hidden">
+          <div className="w-20 h-20 bg-white rounded-md flex items-center justify-center border border-primary/5 relative overflow-hidden">
             <img
               src="/img/footer-icon.png"
               alt="SplitBill Logo"
@@ -121,8 +121,8 @@ export const SocialSplitBillReceipt = React.forwardRef<
       <div className="relative z-10 w-full flex flex-col items-center text-center mt-[-72px]">
         <div className="mb-6 relative">
           <div className="w-36 h-36 bg-white rounded-full flex items-center justify-center relative z-10 overflow-hidden border-4 border-primary/10">
-            <img 
-              src="/img/icon-splitbill.png" 
+            <img
+              src="/img/icon-splitbill.png"
               className="w-24 h-24 object-contain"
               crossOrigin="anonymous"
             />
@@ -383,7 +383,7 @@ export const SocialSplitBillReceipt = React.forwardRef<
                     key={method.id}
                     className="p-6 bg-white border border-slate-100 rounded-[35px] flex items-center gap-8"
                   >
-                    <div className="w-24 h-24 bg-slate-50 rounded-3xl flex items-center justify-center border border-slate-100 shrink-0 relative overflow-hidden">
+                    <div className="w-24 h-24 bg-slate-50 rounded-md flex items-center justify-center border border-slate-100 shrink-0 relative overflow-hidden">
                       {[
                         "bca",
                         "bni",

--- a/src/components/splitbill/VisualReceiptPreview.tsx
+++ b/src/components/splitbill/VisualReceiptPreview.tsx
@@ -113,7 +113,7 @@ export const VisualReceiptPreview = () => {
       {/* Modal Dialog */}
       {isOpen && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/75 backdrop-blur-xs animate-in fade-in duration-200">
-          <div className="relative w-full max-w-md bg-white rounded-3xl overflow-hidden shadow-2xl flex flex-col max-h-[85vh] animate-in zoom-in-95 duration-300">
+          <div className="relative w-full max-w-md bg-white rounded-md overflow-hidden shadow-2xl flex flex-col max-h-[85vh] animate-in zoom-in-95 duration-300">
             {/* Header */}
             <div className="flex justify-between items-center px-5 py-4 border-b border-gray-100 shrink-0">
               <div>

--- a/src/components/splitbill/chat/ActivityInputCard.tsx
+++ b/src/components/splitbill/chat/ActivityInputCard.tsx
@@ -22,7 +22,7 @@ export function ActivityInputCard({
 
   if (isCompleted) {
     return (
-      <div className="rounded-2xl border border-emerald-200 bg-white overflow-hidden">
+      <div className="rounded-md border border-emerald-200 bg-white overflow-hidden">
         <div className="flex items-center gap-2 px-4 py-3 bg-emerald-50 border-b border-emerald-100">
           <div className="w-5 h-5 rounded-full bg-emerald-500 flex items-center justify-center">
             <Check className="w-3 h-3 text-white" />
@@ -67,7 +67,7 @@ export function ActivityInputCard({
   };
 
   return (
-    <div className="rounded-2xl border border-primary/20 bg-white overflow-hidden">
+    <div className="rounded-md border border-primary/20 bg-white overflow-hidden">
       <div className="px-4 py-3 bg-gradient-to-r from-primary/5 to-violet-500/5 border-b border-primary/10 flex items-center gap-2">
         <PenLine className="w-4 h-4 text-primary" />
         <p className="text-xs font-bold text-primary uppercase tracking-wide">

--- a/src/components/splitbill/chat/ChatMessage.tsx
+++ b/src/components/splitbill/chat/ChatMessage.tsx
@@ -91,7 +91,7 @@ export function ChatMessage({
           <div className="w-6 h-6 rounded-full overflow-hidden flex items-center justify-center shrink-0 bg-slate-100">
             <img src="/img/agent-billy.png" alt="Agent Billy" className="w-full h-full object-cover" />
           </div>
-          <div className="bg-slate-100 rounded-2xl rounded-bl-xs overflow-hidden max-w-full">
+          <div className="bg-slate-100 rounded-md rounded-bl-xs overflow-hidden max-w-full">
             {message.imageUrl && (
               <div className="w-full p-2 pb-0">
                 <img src={message.imageUrl} alt="Banner" className="w-full h-auto object-cover rounded-sm" />
@@ -113,7 +113,7 @@ export function ChatMessage({
     // User bubble
     return (
       <div className="flex justify-end">
-        <div className="bg-primary text-white rounded-2xl rounded-br-xs px-4 py-2.5 max-w-[80%]">
+        <div className="bg-primary text-white rounded-md rounded-br-xs px-4 py-2.5 max-w-[80%]">
           <p className="text-sm leading-relaxed">{message.content}</p>
         </div>
       </div>
@@ -132,7 +132,7 @@ export function ChatMessage({
         <div className="flex-1 space-y-2">
           {/* Optional text above the card */}
           {message.content && (
-            <div className="bg-slate-100 rounded-2xl rounded-tl-xs overflow-hidden mr-6">
+            <div className="bg-slate-100 rounded-md rounded-tl-xs overflow-hidden mr-6">
               {message.imageUrl && (
                 <div className="w-full p-2 pb-0">
                   <img src={message.imageUrl} alt="Banner" className="w-full h-auto object-cover rounded-sm" />
@@ -231,7 +231,7 @@ export function TypingIndicator() {
       <div className="w-6 h-6 rounded-full overflow-hidden flex items-center justify-center shrink-0 bg-slate-100">
         <img src="/img/agent-billy.png" alt="Agent Billy" className="w-full h-full object-cover" />
       </div>
-      <div className="bg-slate-100 rounded-2xl rounded-bl-sm px-4 py-3 flex items-center gap-1">
+      <div className="bg-slate-100 rounded-md rounded-bl-sm px-4 py-3 flex items-center gap-1">
         <span className="w-1.5 h-1.5 rounded-full bg-slate-400 animate-bounce" style={{ animationDelay: "0ms" }} />
         <span className="w-1.5 h-1.5 rounded-full bg-slate-400 animate-bounce" style={{ animationDelay: "150ms" }} />
         <span className="w-1.5 h-1.5 rounded-full bg-slate-400 animate-bounce" style={{ animationDelay: "300ms" }} />

--- a/src/components/splitbill/chat/FriendPickerCard.tsx
+++ b/src/components/splitbill/chat/FriendPickerCard.tsx
@@ -29,7 +29,7 @@ export function FriendPickerCard({
   // ── Frozen state (already completed) ──────────────────────────────────────
   if (isCompleted) {
     return (
-      <div className="rounded-2xl border border-primary/15 bg-white overflow-hidden">
+      <div className="rounded-md border border-primary/15 bg-white overflow-hidden">
         <div className="flex items-center gap-2 px-4 py-3 bg-primary/5 border-b border-primary/10">
           <div className="w-5 h-5 rounded-full bg-primary flex items-center justify-center">
             <Check className="w-3 h-3 text-white" />
@@ -78,7 +78,7 @@ export function FriendPickerCard({
   };
 
   return (
-    <div className="rounded-2xl border border-primary/20 bg-white overflow-hidden">
+    <div className="rounded-md border border-primary/20 bg-white overflow-hidden">
       {/* Header */}
       <div className="px-4 py-3 bg-gradient-to-r from-primary/5 to-violet-500/5 border-b border-primary/10">
         <div className="flex items-center gap-2">

--- a/src/components/splitbill/chat/ItemAssignCard.tsx
+++ b/src/components/splitbill/chat/ItemAssignCard.tsx
@@ -36,7 +36,7 @@ export function ItemAssignCard({
       (e) => e.who.length > 0 && e.paidBy
     ).length;
     return (
-      <div className="rounded-2xl border border-primary/15 bg-white overflow-hidden">
+      <div className="rounded-md border border-primary/15 bg-white overflow-hidden">
         <div className="flex items-center gap-2 px-4 py-3 bg-primary/5 border-b border-primary/10">
           <div className="w-5 h-5 rounded-full bg-primary flex items-center justify-center">
             <Check className="w-3 h-3 text-white" />
@@ -108,7 +108,7 @@ export function ItemAssignCard({
   ).length;
 
   return (
-    <div className="rounded-2xl border border-primary/20 bg-white overflow-hidden">
+    <div className="rounded-md border border-primary/20 bg-white overflow-hidden">
       {/* Header */}
       <div className="px-4 py-3 bg-gradient-to-r from-primary/5 to-violet-500/5 border-b border-primary/10">
         <div className="flex items-center justify-between">

--- a/src/components/splitbill/chat/PayerPickerCard.tsx
+++ b/src/components/splitbill/chat/PayerPickerCard.tsx
@@ -20,7 +20,7 @@ export function PayerPickerCard({
   // ── Frozen state (already completed) ──────────────────────────────────────
   if (isCompleted) {
     return (
-      <div className="rounded-2xl border border-primary/15 bg-white overflow-hidden">
+      <div className="rounded-md border border-primary/15 bg-white overflow-hidden">
         <div className="flex items-center gap-2 px-4 py-3 bg-primary/5 border-b border-primary/10">
           <div className="w-5 h-5 rounded-full bg-primary flex items-center justify-center">
             <Check className="w-3 h-3 text-white" />
@@ -41,7 +41,7 @@ export function PayerPickerCard({
   }
 
   return (
-    <div className="rounded-2xl border border-primary/20 bg-white overflow-hidden">
+    <div className="rounded-md border border-primary/20 bg-white overflow-hidden">
       <div className="px-4 py-3 bg-gradient-to-r from-primary/5 to-violet-500/5 border-b border-primary/10 flex items-center gap-2">
         <Wallet className="w-4 h-4 text-primary" />
         <p className="text-xs font-bold text-primary uppercase tracking-wide">

--- a/src/components/splitbill/chat/PaymentPickerCard.tsx
+++ b/src/components/splitbill/chat/PaymentPickerCard.tsx
@@ -33,7 +33,7 @@ export function PaymentPickerCard({
     );
 
     return (
-      <div className="rounded-2xl border border-emerald-200 bg-white overflow-hidden">
+      <div className="rounded-md border border-emerald-200 bg-white overflow-hidden">
         <div className="flex items-center gap-2 px-4 py-3 bg-emerald-50 border-b border-emerald-100">
           <div className="w-5 h-5 rounded-full bg-emerald-500 flex items-center justify-center">
             <Check className="w-3 h-3 text-white" />
@@ -71,7 +71,7 @@ export function PaymentPickerCard({
   };
 
   return (
-    <div className="rounded-2xl border border-primary/20 bg-white overflow-hidden">
+    <div className="rounded-md border border-primary/20 bg-white overflow-hidden">
       <div className="px-4 py-3 bg-gradient-to-r from-primary/5 to-violet-500/5 border-b border-primary/10 flex items-center justify-between">
         <p className="text-xs font-bold text-primary uppercase tracking-wide">
           Pilih Metode Pembayaran

--- a/src/components/splitbill/chat/ReceiptScanCard.tsx
+++ b/src/components/splitbill/chat/ReceiptScanCard.tsx
@@ -69,7 +69,7 @@ export function ReceiptScanCard({
   // ── Guest Limit Barrier ───────────────────────────────────────────────────
   if (!isAuthenticated && guestRemainingScans <= 0 && !isCompleted && !scanResult) {
     return (
-      <div className="rounded-2xl border border-primary/20 bg-white overflow-hidden">
+      <div className="rounded-md border border-primary/20 bg-white overflow-hidden">
         <div className="px-4 py-3 bg-gradient-to-r from-primary/5 to-violet-500/5 border-b border-primary/10 flex items-center gap-2">
           <Sparkles className="w-4 h-4 text-primary" />
           <p className="text-xs font-bold text-primary uppercase tracking-wide">
@@ -122,7 +122,7 @@ export function ReceiptScanCard({
     !scanResult
   ) {
     return (
-      <div className="rounded-2xl border border-primary/20 bg-white overflow-hidden">
+      <div className="rounded-md border border-primary/20 bg-white overflow-hidden">
         <div className="px-4 py-3 bg-gradient-to-r from-primary/5 to-violet-500/5 border-b border-primary/10 flex items-center gap-2">
           <Sparkles className="w-4 h-4 text-primary" />
           <p className="text-xs font-bold text-primary uppercase tracking-wide">
@@ -161,7 +161,7 @@ export function ReceiptScanCard({
   // ── Frozen state ────────────────────────────────────────────────────────────
   if (isCompleted && scannedResult) {
     return (
-      <div className="rounded-2xl border border-emerald-200 bg-white overflow-hidden">
+      <div className="rounded-md border border-emerald-200 bg-white overflow-hidden">
         <div className="flex items-center gap-2 px-4 py-3 bg-emerald-50 border-b border-emerald-100">
           <div className="w-5 h-5 rounded-full bg-emerald-500 flex items-center justify-center">
             <Check className="w-3 h-3 text-white" />
@@ -284,7 +284,7 @@ export function ReceiptScanCard({
   };
 
   return (
-    <div className="rounded-2xl border border-primary/20 bg-white overflow-hidden">
+    <div className="rounded-md border border-primary/20 bg-white overflow-hidden">
       {/* Header */}
       <div className="px-4 py-3 bg-gradient-to-r from-primary/5 to-violet-500/5 border-b border-primary/10 flex items-center gap-2">
         <p className="text-xs font-bold text-primary uppercase tracking-wide">

--- a/src/components/splitbill/chat/ReviewInputCard.tsx
+++ b/src/components/splitbill/chat/ReviewInputCard.tsx
@@ -31,7 +31,7 @@ export function ReviewInputCard({ isCompleted, onSuccess }: ReviewInputCardProps
 
   if (isCompleted) {
     return (
-      <div className="rounded-2xl border border-emerald-200 bg-white overflow-hidden">
+      <div className="rounded-md border border-emerald-200 bg-white overflow-hidden">
         <div className="flex items-center gap-2 px-4 py-3 bg-emerald-50 border-b border-emerald-100">
           <div className="w-5 h-5 rounded-full bg-emerald-500 flex items-center justify-center">
             <Check className="w-3 h-3 text-white" />
@@ -81,7 +81,7 @@ export function ReviewInputCard({ isCompleted, onSuccess }: ReviewInputCardProps
   };
 
   return (
-    <div className="rounded-2xl border border-primary/20 bg-white overflow-hidden">
+    <div className="rounded-md border border-primary/20 bg-white overflow-hidden">
       <div className="px-4 py-3 bg-gradient-to-r from-primary/5 to-violet-500/5 border-b border-primary/10">
         <p className="text-xs font-bold text-primary uppercase tracking-wide">
           Beri Rating & Review Agent Billy

--- a/src/components/splitbill/chat/SummaryCard.tsx
+++ b/src/components/splitbill/chat/SummaryCard.tsx
@@ -82,7 +82,7 @@ export function SummaryCard() {
   };
 
   return (
-    <Card className="overflow-hidden relative shadow-none rounded-2xl">
+    <Card className="overflow-hidden relative shadow-none rounded-md">
       {/* Decorative background element */}
       <div className="absolute top-0 right-0 w-32 h-32 bg-primary/5 rounded-full -mr-16 -mt-16 blur-3xl pointer-events-none" />
 

--- a/src/components/splitbill/chat/TaxMethodCard.tsx
+++ b/src/components/splitbill/chat/TaxMethodCard.tsx
@@ -56,7 +56,7 @@ export function TaxMethodCard({
   // ── Frozen state ─────────────────────────────────────────────────────────────
   if (isCompleted) {
     return (
-      <div className="rounded-2xl border border-primary/15 bg-white overflow-hidden">
+      <div className="rounded-md border border-primary/15 bg-white overflow-hidden">
         <div className="flex items-center gap-2 px-4 py-3 bg-primary/5 border-b border-primary/10">
           <div className="w-5 h-5 rounded-full bg-primary flex items-center justify-center">
             <Check className="w-3 h-3 text-white" />
@@ -143,7 +143,7 @@ export function TaxMethodCard({
   ).length;
 
   return (
-    <div className="rounded-2xl border border-primary/20 bg-white overflow-hidden">
+    <div className="rounded-md border border-primary/20 bg-white overflow-hidden">
       {/* Header */}
       <div className="px-4 py-3 bg-gradient-to-r from-primary/5 to-violet-500/5 border-b border-primary/10">
         <p className="text-xs font-bold text-primary uppercase tracking-wide">

--- a/src/components/subscription/SubscriptionCard.tsx
+++ b/src/components/subscription/SubscriptionCard.tsx
@@ -35,7 +35,7 @@ export function SubscriptionCard({
   return (
     <Card
       className={cn(
-        "relative flex flex-col overflow-hidden rounded-2xl border shadow-sm transition-all",
+        "relative flex flex-col overflow-hidden rounded-md border shadow-sm transition-all",
         isBestValue
           ? "border-primary shadow-primary/10 shadow-md"
           : "border-border/50",

--- a/src/components/subscription/SubscriptionList.tsx
+++ b/src/components/subscription/SubscriptionList.tsx
@@ -13,7 +13,7 @@ interface SubscriptionListProps {
 
 function SkeletonCard() {
   return (
-    <div className="rounded-2xl border border-border/50 overflow-hidden animate-pulse">
+    <div className="rounded-md border border-border/50 overflow-hidden animate-pulse">
       <div className="p-5 space-y-4">
         <div className="flex items-start justify-between gap-2">
           <div className="space-y-2 flex-1">
@@ -35,7 +35,7 @@ function SkeletonCard() {
             </div>
           ))}
         </div>
-        <div className="h-11 bg-muted rounded-2xl w-full" />
+        <div className="h-11 bg-muted rounded-md w-full" />
       </div>
     </div>
   );

--- a/src/components/ui/ActionCard.tsx
+++ b/src/components/ui/ActionCard.tsx
@@ -27,7 +27,7 @@ export const ActionCard = ({
   return (
     <Card
       className={cn(
-        "rounded-lg bg-white backdrop-blur-xs text-card-foreground border-none shadow-soft hover:shadow-lg hover:shadow-primary/5 transition-all cursor-pointer group overflow-hidden h-full",
+        "rounded-sm bg-white backdrop-blur-xs text-card-foreground border-none shadow-soft hover:shadow-lg hover:shadow-primary/5 transition-all cursor-pointer group overflow-hidden h-full",
         className,
       )}
       onClick={onClick}

--- a/src/components/ui/AddButton.tsx
+++ b/src/components/ui/AddButton.tsx
@@ -19,7 +19,7 @@ export function AddButton({
     <Button
       variant={variant}
       className={cn(
-        "w-full h-12 text-base font-bold shadow-lg shadow-primary/20 rounded-2xl",
+        "w-full h-12 text-base font-bold shadow-lg shadow-primary/20 rounded-md",
         className,
       )}
       {...props}

--- a/src/components/ui/ConfirmationModal.tsx
+++ b/src/components/ui/ConfirmationModal.tsx
@@ -39,7 +39,7 @@ export function ConfirmationModal({
 
   return createPortal(
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-[999] p-4 animate-in fade-in duration-200">
-      <div className="max-w-sm w-full bg-white rounded-2xl p-6 shadow-2xl animate-in zoom-in-95 duration-200">
+      <div className="max-w-sm w-full bg-white rounded-md p-6 shadow-2xl animate-in zoom-in-95 duration-200">
         <div className="text-center space-y-4">
           <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto">
             <Icon className="w-8 h-8 text-primary" />
@@ -67,7 +67,7 @@ export function ConfirmationModal({
               className={cn(
                 "flex-1 h-12 font-bold shadow-lg cursor-pointer",
                 confirmButtonClassName ||
-                  "bg-primary text-white shadow-primary/20",
+                "bg-primary text-white shadow-primary/20",
               )}
             >
               {confirmText}

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -20,7 +20,7 @@ export function EmptyState({
   return (
     <div
       className={cn(
-        "flex flex-col items-center justify-center py-6 px-4 rounded-2xl bg-gradient-to-br from-white to-primary/5",
+        "flex flex-col items-center justify-center py-6 px-4 rounded-md bg-gradient-to-br from-white to-primary/5",
         className,
       )}
     >

--- a/src/components/ui/FeatureBanner.tsx
+++ b/src/components/ui/FeatureBanner.tsx
@@ -57,7 +57,7 @@ export const FeatureBanner = ({
 
       <div
         className={cn(
-          "w-full rounded-xl p-6 relative overflow-hidden transition-all duration-300 h-full",
+          "w-full rounded-md p-6 relative overflow-hidden transition-all duration-300 h-full",
           variant === "primary" &&
           "bg-primary text-white shadow-xl shadow-primary/20",
           variant === "secondary" && "bg-[#f0f4ff] text-foreground",
@@ -90,7 +90,7 @@ export const FeatureBanner = ({
               <Button
                 onClick={onCtaClick}
                 className={cn(
-                  "w-full h-12 rounded-2xl font-bold text-base shadow-lg active:scale-95 transition-all flex items-center justify-center gap-2 relative overflow-hidden",
+                  "w-full h-12 rounded-md font-bold text-base shadow-lg active:scale-95 transition-all flex items-center justify-center gap-2 relative overflow-hidden",
                   variant === "primary"
                     ? "bg-white text-primary hover:bg-white/95"
                     : "bg-primary text-white hover:opacity-90",

--- a/src/components/ui/InfoBanner.tsx
+++ b/src/components/ui/InfoBanner.tsx
@@ -65,7 +65,7 @@ export const InfoBanner = ({
     return (
       <div
         className={cn(
-          "py-4 flex flex-col items-center justify-center gap-3 border-1 border-dashed rounded-2xl animate-in fade-in zoom-in-95",
+          "py-4 flex flex-col items-center justify-center gap-3 border-1 border-dashed rounded-md animate-in fade-in zoom-in-95",
           currentStyle.container,
           className,
         )}

--- a/src/components/ui/InfoModal.tsx
+++ b/src/components/ui/InfoModal.tsx
@@ -26,7 +26,7 @@ export function InfoModal({
 
   return createPortal(
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-[999] p-4 animate-in fade-in duration-200">
-      <div className="max-w-sm w-full bg-white rounded-2xl p-6 shadow-2xl animate-in zoom-in-95 duration-200 relative overflow-hidden">
+      <div className="max-w-sm w-full bg-white rounded-md p-6 shadow-2xl animate-in zoom-in-95 duration-200 relative overflow-hidden">
         {/* Decorative background element */}
         <div className="absolute top-0 right-0 w-24 h-24 bg-primary/5 rounded-full -mr-12 -mt-12 transition-transform" />
 
@@ -38,7 +38,7 @@ export function InfoModal({
         </button>
 
         <div className="text-center space-y-4 pt-2">
-          <div className="w-12 h-12 bg-primary/10 rounded-2xl flex items-center justify-center mx-auto rotate-12">
+          <div className="w-12 h-12 bg-primary/10 rounded-md flex items-center justify-center mx-auto rotate-12">
             <Info className="w-6 h-6 text-primary -rotate-12" />
           </div>
 

--- a/src/components/ui/LoadingModal.tsx
+++ b/src/components/ui/LoadingModal.tsx
@@ -89,7 +89,7 @@ export function LoadingModal({ isOpen, image }: LoadingModalProps) {
       <div className="relative max-w-md w-full flex flex-col items-center text-center gap-6 z-10">
 
         {/* Square Scan Frame — shows the uploaded receipt with a sweeping scan line */}
-        <div className="relative w-60 h-60 md:w-64 md:h-64 rounded-2xl overflow-hidden border border-primary/15 bg-slate-50">
+        <div className="relative w-60 h-60 md:w-64 md:h-64 rounded-md overflow-hidden border border-primary/15 bg-slate-50">
           {image ? (
             <img
               src={image}

--- a/src/components/ui/MerchandisingBanner.tsx
+++ b/src/components/ui/MerchandisingBanner.tsx
@@ -59,7 +59,7 @@ export const MerchandisingBanner = ({
         </button>
 
         {/* Image Content */}
-        <div className="relative overflow-hidden rounded-3xl">
+        <div className="relative overflow-hidden rounded-md">
           <Image
             src={imageSrc}
             alt={altText}

--- a/src/components/wallet/PaymentMethodCard.tsx
+++ b/src/components/wallet/PaymentMethodCard.tsx
@@ -33,7 +33,7 @@ export const PaymentMethodCard = ({
   return (
     <div
       onClick={() => router.push(`/wallet/${method.id}`)}
-      className="relative w-[42vw] sm:w-[220px] shrink-0 aspect-[1.4/1] rounded-2xl overflow-hidden transition-all duration-300 font-sans select-none bg-white border border-slate-200 text-slate-800 group cursor-pointer"
+      className="relative w-[42vw] sm:w-[220px] shrink-0 aspect-[1.4/1] rounded-md overflow-hidden transition-all duration-300 font-sans select-none bg-white border border-slate-200 text-slate-800 group cursor-pointer"
     >
       <div className="flex flex-col h-full p-3.5 justify-between">
         {/* Top: logo kiri atas + type badge kanan */}

--- a/src/components/wallet/PaymentMethodsTab.tsx
+++ b/src/components/wallet/PaymentMethodsTab.tsx
@@ -38,7 +38,7 @@ export const PaymentMethodsTab = () => {
     <div className="flex-1 flex flex-col space-y-6 pb-4">
       {/* Empty State / Intro */}
       {paymentMethods.length === 0 && (
-        <div className="flex flex-col items-center justify-center py-8 px-6 animate-in fade-in zoom-in duration-500 rounded-2xl bg-white border border-primary/10 shadow-soft">
+        <div className="flex flex-col items-center justify-center py-8 px-6 animate-in fade-in zoom-in duration-500 rounded-md bg-white border border-primary/10 shadow-soft">
           <div className="w-20 h-20 rounded-full flex items-center justify-center mb-4 bg-primary/5">
             <img
               src="/img/menu-wallet.png"
@@ -190,7 +190,7 @@ export const PaymentMethodsTab = () => {
       {/* Share All Card (Premium Box) */}
       {paymentMethods.length > 0 && (
         <div className="px-1 animate-in fade-in slide-in-from-bottom-6 duration-700 delay-150">
-          <div className="p-5 rounded-2xl bg-gradient-to-br from-primary/10 via-primary/5 to-transparent border border-primary/20 relative overflow-hidden group cursor-pointer hover:shadow-soft transition-all active:scale-[0.98]">
+          <div className="p-5 rounded-md bg-gradient-to-br from-primary/10 via-primary/5 to-transparent border border-primary/20 relative overflow-hidden group cursor-pointer hover:shadow-soft transition-all active:scale-[0.98]">
             <div className="absolute top-0 right-0 p-4 opacity-10 group-hover:scale-110 transition-transform duration-500">
               <Share2 className="w-20 h-20 text-primary" />
             </div>
@@ -244,7 +244,7 @@ export const PaymentMethodsTab = () => {
 
       {/* Feature Highlights (Premium Soft Grid) */}
       <div className="grid grid-cols-2 gap-3 px-1 animate-in slide-in-from-bottom-8 duration-700 delay-200">
-        <div className="p-4 rounded-2xl bg-white border border-primary/5 flex flex-col gap-2 group hover:scale-[1.02] transition-all duration-300 cursor-pointer shadow-soft">
+        <div className="p-4 rounded-md bg-white border border-primary/5 flex flex-col gap-2 group hover:scale-[1.02] transition-all duration-300 cursor-pointer shadow-soft">
           <ShieldCheck className="w-5 h-5 text-emerald-500 mb-1" />
           <h4 className="font-bold text-xs sm:text-sm text-foreground">
             Aman & Privat
@@ -254,7 +254,7 @@ export const PaymentMethodsTab = () => {
           </p>
         </div>
 
-        <div className="p-4 rounded-2xl bg-white border border-primary/5 flex flex-col gap-2 group hover:scale-[1.02] transition-all duration-300 cursor-pointer shadow-soft">
+        <div className="p-4 rounded-md bg-white border border-primary/5 flex flex-col gap-2 group hover:scale-[1.02] transition-all duration-300 cursor-pointer shadow-soft">
           <Share2 className="w-5 h-5 text-blue-500 mb-1" />
           <h4 className="font-bold text-xs sm:text-sm text-foreground">
             Sat Set Share
@@ -264,7 +264,7 @@ export const PaymentMethodsTab = () => {
           </p>
         </div>
 
-        <div className="p-4 rounded-2xl bg-white border border-primary/5 flex flex-col gap-2 group hover:scale-[1.02] transition-all duration-300 cursor-pointer shadow-soft">
+        <div className="p-4 rounded-md bg-white border border-primary/5 flex flex-col gap-2 group hover:scale-[1.02] transition-all duration-300 cursor-pointer shadow-soft">
           <WifiOff className="w-5 h-5 text-slate-500 mb-1" />
           <h4 className="font-bold text-xs sm:text-sm text-foreground">
             Mode Offline
@@ -274,7 +274,7 @@ export const PaymentMethodsTab = () => {
           </p>
         </div>
 
-        <div className="p-4 rounded-2xl bg-white border border-primary/5 flex flex-col gap-2 group hover:scale-[1.02] transition-all duration-300 cursor-pointer shadow-soft">
+        <div className="p-4 rounded-md bg-white border border-primary/5 flex flex-col gap-2 group hover:scale-[1.02] transition-all duration-300 cursor-pointer shadow-soft">
           <LayoutGrid className="w-5 h-5 text-purple-500 mb-1" />
           <h4 className="font-bold text-xs sm:text-sm text-foreground">
             Rapi & Praktis

--- a/src/components/wallet/SharedGoalsTab.tsx
+++ b/src/components/wallet/SharedGoalsTab.tsx
@@ -30,7 +30,7 @@ export const SharedGoalsTab = ({
   return (
     <div className="space-y-4">
       {goals.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-12 px-4 text-center border-2 border-dashed border-muted/40 rounded-2xl bg-muted/5">
+        <div className="flex flex-col items-center justify-center py-12 px-4 text-center border-2 border-dashed border-muted/40 rounded-md bg-muted/5">
           <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mb-4 text-primary">
             <Target className="w-8 h-8" />
           </div>


### PR DESCRIPTION
## Summary
- **perf(homepage)** — Hero's scan demo settled in 8.5s and background aurora
  blobs animated forever; Lighthouse counts every pixel change until the page
  looks visually stable, so both tanked Speed Index (0.01 score) despite
  FCP/LCP already being fine. Shortened the demo timeline, capped decorative
  motion to a single pass.
- **fix(homepage)** — Several `next/dynamic` imports (`HomepagePromoSlider`,
  `ChatAgentFAB`, `ChatRoom`, `HomepageAIScanCard`) were missing a `loading`
  fallback. Without one, a client-side chunk fetch suspends to the root
  `app/loading.tsx` and blanks the *entire* page instead of just that
  section — this was the "loading glitch on refresh" bug. Also deferred the
  chat widget mount to idle so it doesn't compete with hero hydration.
- **refactor(auth)** — Removed the app-wide next-auth `SessionProvider`.
  `useSession()` has zero consumers in this codebase (auth is a separate
  custom JWT store); the provider was only firing a redundant session fetch
  on every page load plus a background refetch-on-focus loop for a context
  nothing read. `signIn`/`signOut`/`getSession` all work standalone —
  verified against next-auth's source directly, not just docs.
- **style** — Continued the border-radius → design-token migration
  (`rounded-2xl/lg/xl` → `rounded-md/sm/xs`) started in d0202eb across the
  remaining app screens. No behavioral change.
- **fix(onboarding)** — `TutorialOverlay`'s spotlight handler did both rect
  recalculation *and* `scrollIntoView`, wired to the `scroll` listener —
  so scrolling kept re-triggering a smooth-scroll back to the target,
  fighting the user's own scroll. Split into `recalculateSpotlight`
  (resize/scroll) and `scrollToTarget` (once, on step open).
