### PR TITLE
fix(seo): use www subdomain in branding text and share captions

### DIFF
--- a/src/app/privacy/PrivacyClientPage.tsx
+++ b/src/app/privacy/PrivacyClientPage.tsx
@@ -768,7 +768,7 @@ export default function PrivacyClientPage() {
                     Kebijakan Privasi ini berlaku sejak 16 Mei 2026
                   </p>
                   <p className="text-xs">
-                    © 2026 Split Bill Online - splitbill.my.id
+                    © 2026 Split Bill Online - www.splitbill.my.id
                   </p>
                   <p className="text-[10px] italic">
                     Dokumen ini disusun sesuai dengan UU No. 27 Tahun 2022 tentang

--- a/src/app/split-bill/SplitBillClientPage.tsx
+++ b/src/app/split-bill/SplitBillClientPage.tsx
@@ -1381,7 +1381,7 @@ const SplitBillContent = () => {
                     const instructionsText = calculationResult.settlementInstructions.length > 0
                       ? "\n\nRincian Transfer:\n" + calculationResult.settlementInstructions.map(inst => `• ${inst.from} ➡️ ${inst.to}: ${formatCurrency(inst.amount)}`).join("\n")
                       : "";
-                    const caption = `💸 Habis seru-seruan bareng di "${activityName || "Makan-makan"}"!\n\nTotal tagihannya ${formatCurrency(totalSpent)}. Biar pertemanan makin asik, yuk lunasin tagihannya ya! 😉✨${instructionsText}\n\nCek rincian lengkapnya di sini:\n🔗 ${shareUrl}\n\nPowered by splitbill.my.id`;
+                    const caption = `💸 Habis seru-seruan bareng di "${activityName || "Makan-makan"}"!\n\nTotal tagihannya ${formatCurrency(totalSpent)}. Biar pertemanan makin asik, yuk lunasin tagihannya ya! 😉✨${instructionsText}\n\nCek rincian lengkapnya di sini:\n🔗 ${shareUrl}\n\nPowered by www.splitbill.my.id`;
 
                     if (typeof navigator !== "undefined" && navigator.share) {
                       navigator.share({

--- a/src/app/terms/TermsClientPage.tsx
+++ b/src/app/terms/TermsClientPage.tsx
@@ -645,7 +645,7 @@ export default function TermsClientPage() {
                     Syarat dan Ketentuan ini berlaku sejak 16 Mei 2026
                   </p>
                   <p className="text-xs">
-                    © 2026 Split Bill Online - splitbill.my.id
+                    © 2026 Split Bill Online - www.splitbill.my.id
                   </p>
                   <p className="text-[10px] italic">
                     Dokumen ini disusun sesuai dengan UU ITE, UU PDP, UU

--- a/src/components/split-later/BucketSettlement.tsx
+++ b/src/components/split-later/BucketSettlement.tsx
@@ -327,7 +327,7 @@ export const BucketSettlement = ({
       });
 
       const fileName = `SplitLater-${bucket.title?.replace(/\s+/g, "-") || "Summary"}-${Date.now()}.png`;
-      const caption = `💸 Settlement Rangkuman untuk "${bucket.emoji || "✈️"} ${bucket.title || "Trip Kami"}"!\n\nTotal pengeluaran trip ini ${formatToIDR(totalSpend)}.\n\nPowered by splitbill.my.id`;
+      const caption = `💸 Settlement Rangkuman untuk "${bucket.emoji || "✈️"} ${bucket.title || "Trip Kami"}"!\n\nTotal pengeluaran trip ini ${formatToIDR(totalSpend)}.\n\nPowered by www.splitbill.my.id`;
 
       if (
         typeof navigator !== "undefined" &&

--- a/src/components/split-later/SocialSplitLaterReceipt.tsx
+++ b/src/components/split-later/SocialSplitLaterReceipt.tsx
@@ -459,7 +459,7 @@ export const SocialSplitLaterReceipt = React.forwardRef<
           <span className="text-primary font-black">SplitBill</span>
         </p>
         <p className="text-primary font-black text-3xl mt-3 tracking-tighter">
-          splitbill.my.id
+          www.splitbill.my.id
         </p>
       </div>
     </div>

--- a/src/components/splitbill/BillSummary.tsx
+++ b/src/components/splitbill/BillSummary.tsx
@@ -159,7 +159,7 @@ export const BillSummary = React.forwardRef<BillSummaryHandle, BillSummaryProps>
           ? "\n\nRincian Transfer:\n" + settlementInstructions.map(inst => `• ${inst.from} ➡️ ${inst.to}: ${formatToIDR(inst.amount)}`).join("\n")
           : "";
 
-        const caption = `💸 Habis seru-seruan bareng di "${activityName || "Makan-makan"}"!\n\nTotal tagihannya ${formatToIDR(totalSpent)}. Biar pertemanan makin asik, yuk lunasin tagihannya ya! 😉✨${instructionsText}\n\nCek rincian lengkapnya di sini:\n🔗 ${shareUrl}\n\nPowered by splitbill.my.id`;
+        const caption = `💸 Habis seru-seruan bareng di "${activityName || "Makan-makan"}"!\n\nTotal tagihannya ${formatToIDR(totalSpent)}. Biar pertemanan makin asik, yuk lunasin tagihannya ya! 😉✨${instructionsText}\n\nCek rincian lengkapnya di sini:\n🔗 ${shareUrl}\n\nPowered by www.splitbill.my.id`;
 
         // Pre-copy text to clipboard as many apps ignore 'text' when 'files' are shared
         try {
@@ -229,7 +229,7 @@ export const BillSummary = React.forwardRef<BillSummaryHandle, BillSummaryProps>
         ? "\n\nRincian Transfer:\n" + settlementInstructions.map(inst => `• ${inst.from} ➡️ ${inst.to}: ${formatToIDR(inst.amount)}`).join("\n")
         : "";
 
-      const caption = `💸 Habis seru-seruan bareng di "${activityName || "Makan-makan"}"!\n\nTotal tagihannya ${formatToIDR(totalSpent)}. Biar pertemanan makin asik, yuk lunasin tagihannya ya! 😉✨${instructionsText}\n\nCek rincian lengkapnya di sini:\n🔗 ${shareUrl}\n\nPowered by splitbill.my.id`;
+      const caption = `💸 Habis seru-seruan bareng di "${activityName || "Makan-makan"}"!\n\nTotal tagihannya ${formatToIDR(totalSpent)}. Biar pertemanan makin asik, yuk lunasin tagihannya ya! 😉✨${instructionsText}\n\nCek rincian lengkapnya di sini:\n🔗 ${shareUrl}\n\nPowered by www.splitbill.my.id`;
 
       if (
         typeof navigator !== "undefined" &&

--- a/src/components/splitbill/SocialSplitBillReceipt.tsx
+++ b/src/components/splitbill/SocialSplitBillReceipt.tsx
@@ -490,7 +490,7 @@ export const SocialSplitBillReceipt = React.forwardRef<
           <span className="text-primary font-black">SplitBill</span>
         </p>
         <p className="text-primary font-black text-3xl mt-3 tracking-tighter">
-          splitbill.my.id
+          www.splitbill.my.id
         </p>
       </div>
     </div>


### PR DESCRIPTION
Domain migrated non-www -> www; footer copyright, share captions, and receipt branding still referenced the old apex domain.