### PR TITLE
feat(home): add configurable entry-point cards to member homepage

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -57,6 +57,12 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: "https",
+        hostname: "www.splitbill.my.id",
+        port: "",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
         hostname: "splitbillonline.netlify.app",
         port: "",
         pathname: "/**",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     "build": "next build",
     "start": "next start",
     "lint": "eslint"

--- a/src/app/split-bill/SplitBillClientPage.tsx
+++ b/src/app/split-bill/SplitBillClientPage.tsx
@@ -18,6 +18,7 @@ import { Input } from "@/components/ui/Input";
 import { Button } from "@/components/ui/Button";
 import { LoadingIndicator } from "@/components/ui/LoadingIndicator";
 import { useSplitBillStore } from "@/store/useSplitBillStore";
+import { useSplitBillChatStore } from "@/store/useSplitBillChatStore";
 import { useSplitLaterStore } from "@/store/useSplitLaterStore";
 import { useWalletStore, type PaymentMethod } from "@/store/useWalletStore";
 import { useBillCalculations } from "@/hooks/useBillCalculations";
@@ -89,6 +90,13 @@ const SplitBillContent = () => {
     sourceReceiptId,
     scannedTotalAmount,
   } = useSplitBillStore();
+
+  useEffect(() => {
+    if (searchParams.get("agent") === "billy") {
+      useSplitBillChatStore.getState().openChat();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
 
   useEffect(() => {
     const source = searchParams.get("source");

--- a/src/components/home/EntryPointCard.tsx
+++ b/src/components/home/EntryPointCard.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import React from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { EntryPointCardData } from "@/lib/types/entryPoint";
+
+interface EntryPointCardProps {
+  data: EntryPointCardData;
+  className?: string;
+}
+
+export const EntryPointCard = ({ data, className }: EntryPointCardProps) => {
+  const {
+    imageUrl,
+    imageAlt,
+    title,
+    subtitle,
+    ctaText,
+    url,
+    footerText,
+    footerIconUrl,
+    ribbonText,
+  } = data;
+
+  const isExternal = !!url && url.startsWith("http");
+
+  const cardBody = (
+    <div
+      className={cn(
+        "group flex flex-col w-full overflow-hidden rounded-md bg-white border border-border shadow-soft transition-all duration-300",
+        url && "cursor-pointer hover:shadow-lg hover:shadow-primary/5",
+        className,
+      )}
+    >
+      <div className="relative aspect-square w-full overflow-hidden bg-slate-50">
+        <Image
+          src={imageUrl || "/img/pwa-banner.png"}
+          alt={imageAlt}
+          fill
+          sizes="(max-width: 640px) 50vw, 200px"
+          className="object-cover transition-transform duration-500 group-hover:scale-105"
+        />
+        {ribbonText && (
+          <span className="absolute bottom-0 left-0 rounded-tr-sm bg-gradient-to-r from-violet-400 via-pink-400 to-primary/70 px-2.5 py-1.5 text-[10px] font-black uppercase leading-none tracking-wide text-white shadow-sm">
+            {ribbonText}
+          </span>
+        )}
+      </div>
+
+      <div className="flex flex-1 flex-col gap-1 p-2.5 lg:p-4 lg:gap-1.5">
+        <h3 className="text-sm lg:text-sm font-bold text-slate-800 leading-snug line-clamp-2">
+          {title}
+        </h3>
+
+        {subtitle && (
+          <p className="text-[10px] lg:text-xs text-muted-foreground font-medium leading-tight line-clamp-2">
+            {subtitle}
+          </p>
+        )}
+
+        {ctaText && (
+          <span className="mt-0.5 inline-flex items-center gap-0.5 text-[10px] lg:text-xs font-bold text-primary">
+            {ctaText}
+            <ArrowRight className="w-2.5 h-2.5 lg:w-3 lg:h-3 transition-transform group-hover:translate-x-0.5" />
+          </span>
+        )}
+
+        {footerText && (
+          <div className="mt-auto pt-1.5 flex items-center gap-1 border-t border-slate-100 text-[9.5px] lg:text-[11px] text-muted-foreground font-medium">
+            {footerIconUrl && (
+              <span className="relative w-4 h-4 shrink-0 overflow-hidden rounded-full">
+                <Image
+                  src={footerIconUrl}
+                  alt=""
+                  fill
+                  sizes="16px"
+                  className="object-cover"
+                />
+              </span>
+            )}
+            <span className="truncate">{footerText}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  if (!url) return cardBody;
+
+  if (isExternal) {
+    return (
+      <a href={url} target="_blank" rel="noopener noreferrer" className="block">
+        {cardBody}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={url} className="block">
+      {cardBody}
+    </Link>
+  );
+};

--- a/src/components/home/EntryPointSection.tsx
+++ b/src/components/home/EntryPointSection.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { EntryPointCard } from "@/components/home/EntryPointCard";
+import { EntryPointCardData } from "@/lib/types/entryPoint";
+import { fetchEntryPoints } from "@/lib/api/entryPoints";
+import { Skeleton } from "@/components/ui/Skeleton";
+
+interface EntryPointSectionProps {
+  title?: string;
+  placement?: string;
+}
+
+const SKELETON_COUNT = 4;
+
+export const EntryPointSection = ({
+  title,
+  placement = "homepage-member",
+}: EntryPointSectionProps) => {
+  const [items, setItems] = useState<EntryPointCardData[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+
+    fetchEntryPoints(placement)
+      .then((data) => {
+        if (active) setItems(data);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [placement]);
+
+  if (!loading && items.length === 0) return null;
+
+  return (
+    <section className="space-y-3">
+      {title && (
+        <h2 className="px-1 text-md font-bold text-foreground">{title}</h2>
+      )}
+
+      <div className="columns-2 gap-3">
+        {loading
+          ? Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+              <div key={i} className="mb-3 break-inside-avoid space-y-2 rounded-md border border-border bg-white p-2.5">
+                <Skeleton className="aspect-square w-full rounded-sm" />
+                <Skeleton className="h-3 w-full" />
+                <Skeleton className="h-3 w-2/3" />
+              </div>
+            ))
+          : items.map((item) => (
+              <div key={item.id} className="mb-3 break-inside-avoid">
+                <EntryPointCard data={item} />
+              </div>
+            ))}
+      </div>
+    </section>
+  );
+};

--- a/src/components/member/MemberHomeContent.tsx
+++ b/src/components/member/MemberHomeContent.tsx
@@ -11,6 +11,7 @@ import { MemberGettingStarted } from "@/components/member/MemberGettingStarted";
 import { ReviewRewardBanner } from "@/components/home/ReviewRewardBanner";
 import { FAQCard } from "@/components/home/FAQCard";
 import { AIScanEncourageBanner } from "@/components/home/AIScanEncourageBanner";
+import { EntryPointSection } from "@/components/home/EntryPointSection";
 import { PromoBanner } from "@/components/ui/PromoBanner";
 import { useSplitBillStore } from "@/store/useSplitBillStore";
 import { useWalletStore } from "@/store/useWalletStore";
@@ -107,6 +108,7 @@ export function MemberHomeContent({ singleColumn = false }: MemberHomeContentPro
           </section>
         )}
 
+        {/* Hidden for now — re-enable when ready
         <section className="space-y-4">
           <div className="flex flex-col items-start px-1">
             <div className="space-y-1">
@@ -120,6 +122,9 @@ export function MemberHomeContent({ singleColumn = false }: MemberHomeContentPro
           </div>
           <MemberGettingStarted />
         </section>
+        */}
+
+        <EntryPointSection title="Rekomendasi Buat Kamu" />
 
         <section className="space-y-4">
           <PromoBanner isCompact image="/img/promoBanner-split-later.jpg" />

--- a/src/components/profile/ProfilePanel.tsx
+++ b/src/components/profile/ProfilePanel.tsx
@@ -21,7 +21,6 @@ import { cn, getAvatarUrl } from "@/lib/utils";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { useAuthStore } from "@/lib/stores/authStore";
-import { AdsCarousel } from "@/components/home/AdsCarousel";
 
 import { useWalletStore } from "@/store/useWalletStore";
 import { PaymentMethodCard } from "@/components/wallet/PaymentMethodCard";
@@ -354,10 +353,6 @@ export function ProfilePanel() {
               </div>
             </MenuItem>
           </MenuGroup>
-
-          <div className="pt-2 pb-2 mb-0">
-            <AdsCarousel />
-          </div>
 
           <div className="pt-2">
             <Button

--- a/src/lib/api/entryPoints.ts
+++ b/src/lib/api/entryPoints.ts
@@ -1,0 +1,37 @@
+import { apiClient } from "./client";
+import { EntryPointCardData } from "@/lib/types/entryPoint";
+
+interface EntryPointApiItem extends Omit<EntryPointCardData, "id"> {
+  _id: string;
+}
+
+interface EntryPointsApiResponse {
+  success: boolean;
+  data: EntryPointApiItem[];
+}
+
+function mapEntryPoint(raw: EntryPointApiItem): EntryPointCardData {
+  return {
+    id: raw._id,
+    imageUrl: raw.imageUrl,
+    imageAlt: raw.imageAlt,
+    title: raw.title,
+    subtitle: raw.subtitle ?? undefined,
+    ctaText: raw.ctaText ?? undefined,
+    url: raw.url ?? undefined,
+    footerText: raw.footerText ?? undefined,
+    footerIconUrl: raw.footerIconUrl ?? undefined,
+    ribbonText: raw.ribbonText ?? undefined,
+  };
+}
+
+export async function fetchEntryPoints(
+  placement = "homepage-member",
+): Promise<EntryPointCardData[]> {
+  const response = await apiClient.request<EntryPointsApiResponse>(
+    `/api/entry-points?placement=${encodeURIComponent(placement)}`,
+    { method: "GET", skipAuth: true },
+  );
+
+  return (response.data || []).map(mapEntryPoint);
+}

--- a/src/lib/types/entryPoint.ts
+++ b/src/lib/types/entryPoint.ts
@@ -1,0 +1,12 @@
+export interface EntryPointCardData {
+  id: string;
+  imageUrl: string;
+  imageAlt: string;
+  title: string;
+  subtitle?: string;
+  ctaText?: string;
+  url?: string;
+  footerText?: string;
+  footerIconUrl?: string;
+  ribbonText?: string;
+}


### PR DESCRIPTION
Multipurpose entry-point card + masonry section, backed by the new splitbill-be /api/entry-points endpoint (no local fallback/cache — always fetches fresh, skeleton while loading). Also:
- deep-link /split-bill?agent=billy to auto-open the Billy chat agent
- whitelist www.splitbill.my.id for next/image
- dev script uses webpack (Turbopack native crash on this machine)
- remove unused Tips & Update carousel from profile panel