### PR TITLE
fix(home): render entry-point cards in two masonry columns

### DIFF
--- a/src/components/home/EntryPointSection.tsx
+++ b/src/components/home/EntryPointSection.tsx
@@ -39,27 +39,42 @@ export const EntryPointSection = ({
 
   if (!loading && items.length === 0) return null;
 
+  const skeletons = Array.from({ length: SKELETON_COUNT });
+  const leftSkeletons = skeletons.filter((_, i) => i % 2 === 0);
+  const rightSkeletons = skeletons.filter((_, i) => i % 2 === 1);
+  const leftItems = items.filter((_, i) => i % 2 === 0);
+  const rightItems = items.filter((_, i) => i % 2 === 1);
+
   return (
     <section className="space-y-3">
       {title && (
         <h2 className="px-1 text-md font-bold text-foreground">{title}</h2>
       )}
 
-      <div className="columns-2 gap-3">
-        {loading
-          ? Array.from({ length: SKELETON_COUNT }).map((_, i) => (
-              <div key={i} className="mb-3 break-inside-avoid space-y-2 rounded-md border border-border bg-white p-2.5">
-                <Skeleton className="aspect-square w-full rounded-sm" />
-                <Skeleton className="h-3 w-full" />
-                <Skeleton className="h-3 w-2/3" />
-              </div>
-            ))
-          : items.map((item) => (
-              <div key={item.id} className="mb-3 break-inside-avoid">
-                <EntryPointCard data={item} />
-              </div>
+      <div className="flex gap-3">
+        <div className="flex flex-1 flex-col gap-3">
+          {loading
+            ? leftSkeletons.map((_, i) => <EntryPointCardSkeleton key={i} />)
+            : leftItems.map((item) => (
+              <EntryPointCard key={item.id} data={item} />
             ))}
+        </div>
+        <div className="flex flex-1 flex-col gap-3">
+          {loading
+            ? rightSkeletons.map((_, i) => <EntryPointCardSkeleton key={i} />)
+            : rightItems.map((item) => (
+              <EntryPointCard key={item.id} data={item} />
+            ))}
+        </div>
       </div>
     </section>
   );
 };
+
+const EntryPointCardSkeleton = () => (
+  <div className="space-y-2 rounded-md border border-border bg-white p-2.5">
+    <Skeleton className="aspect-square w-full rounded-sm" />
+    <Skeleton className="h-3 w-full" />
+    <Skeleton className="h-3 w-2/3" />
+  </div>
+);


### PR DESCRIPTION
Split by index parity instead of CSS columns-2, guaranteeing an even left/right split and preserving left-to-right reading order.