### PR TITLE
feat: bridge member UI to the splitbill-native app shell

### DIFF
--- a/src/app/member/layout.tsx
+++ b/src/app/member/layout.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { Menu, X } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { cn, isNativeAppWebView } from "@/lib/utils";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
@@ -15,6 +15,7 @@ import { PwaInstallBanner } from "@/components/member/PwaInstallBanner";
 export default function MemberV2Layout({ children }: { children: React.ReactNode }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isMounted, setIsMounted] = useState(false);
+  const [isNativeApp, setIsNativeApp] = useState(false);
   const [headerHeight, setHeaderHeight] = useState(0);
   const [bannerHeight, setBannerHeight] = useState(0);
   const headerWrapperRef = React.useRef<HTMLDivElement>(null);
@@ -22,6 +23,7 @@ export default function MemberV2Layout({ children }: { children: React.ReactNode
 
   useEffect(() => {
     setIsMounted(true);
+    setIsNativeApp(isNativeAppWebView());
   }, []);
 
   useEffect(() => {
@@ -53,36 +55,40 @@ export default function MemberV2Layout({ children }: { children: React.ReactNode
   return (
     <ProtectedRoute>
       <div className="min-h-screen bg-background flex flex-col items-center">
-        <div ref={headerWrapperRef} className="fixed top-0 left-0 right-0 z-50">
-          <Header
-            wide
-            sticky={false}
-            containerClassName="max-w-[600px] lg:max-w-5xl px-4 sm:px-6 lg:px-8"
-            leftContent={
-              <button
-                onClick={() => setIsMenuOpen(true)}
-                className="lg:hidden p-2 -ml-1 rounded-full hover:bg-white/10 transition-colors cursor-pointer text-white"
-                aria-label="Buka menu"
-              >
-                <Menu className="w-5 h-5" />
-              </button>
-            }
-          />
-        </div>
+        {!isNativeApp && (
+          <>
+            <div ref={headerWrapperRef} className="fixed top-0 left-0 right-0 z-50">
+              <Header
+                wide
+                sticky={false}
+                containerClassName="max-w-[600px] lg:max-w-5xl px-4 sm:px-6 lg:px-8"
+                leftContent={
+                  <button
+                    onClick={() => setIsMenuOpen(true)}
+                    className="lg:hidden p-2 -ml-1 rounded-full hover:bg-white/10 transition-colors cursor-pointer text-white"
+                    aria-label="Buka menu"
+                  >
+                    <Menu className="w-5 h-5" />
+                  </button>
+                }
+              />
+            </div>
 
-        <div
-          ref={bannerWrapperRef}
-          className="fixed left-0 right-0 z-40"
-          style={{ top: headerHeight }}
-        >
-          <PwaInstallBanner containerClassName="max-w-[600px] lg:max-w-5xl px-4 sm:px-6 lg:px-8" />
-        </div>
+            <div
+              ref={bannerWrapperRef}
+              className="fixed left-0 right-0 z-40"
+              style={{ top: headerHeight }}
+            >
+              <PwaInstallBanner containerClassName="max-w-[600px] lg:max-w-5xl px-4 sm:px-6 lg:px-8" />
+            </div>
 
-        {/* Spacer: header + banner are fixed (out of flow), push content down by their measured height */}
-        <div
-          className={headerHeight === 0 ? "h-14 lg:h-16" : undefined}
-          style={headerHeight > 0 ? { height: headerHeight + bannerHeight } : undefined}
-        />
+            {/* Spacer: header + banner are fixed (out of flow), push content down by their measured height */}
+            <div
+              className={headerHeight === 0 ? "h-14 lg:h-16" : undefined}
+              style={headerHeight > 0 ? { height: headerHeight + bannerHeight } : undefined}
+            />
+          </>
+        )}
 
         <div className="w-full max-w-5xl mx-auto px-4 sm:px-6 pb-4 sm:pb-0 lg:px-8 flex lg:gap-8">
           {/* Desktop persistent sidebar */}
@@ -98,7 +104,7 @@ export default function MemberV2Layout({ children }: { children: React.ReactNode
           </main>
         </div>
 
-        <Footer />
+        {!isNativeApp && <Footer />}
 
         <ChatAgentFAB bottomClass="bottom-24 lg:bottom-6" />
         <ChatRoom />

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import React, { useRef, useCallback, useState } from "react";
+import React, { useRef, useCallback, useState, useEffect } from "react";
 import { ReceiptText, ScrollText, History, Home, Camera } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { cn, isNativeAppWebView } from "@/lib/utils";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useSplitBillStore } from "@/store/useSplitBillStore";
@@ -18,6 +18,11 @@ export const Footer = () => {
   const { setPendingCapturedImage } = useSplitBillStore();
   const { isAuthenticated } = useAuthStore();
   const [isScanChoiceOpen, setIsScanChoiceOpen] = useState(false);
+  const [isNativeApp, setIsNativeApp] = useState(false);
+
+  useEffect(() => {
+    setIsNativeApp(isNativeAppWebView());
+  }, []);
 
   const isActive = (path: string) => {
     if (path === "/member" && (pathname === "/" || pathname === "/member")) return true;
@@ -140,6 +145,9 @@ export const Footer = () => {
       </Link>
     );
   };
+
+  // Native shell has its own bottom tab bar — avoid a duplicate nav here.
+  if (isNativeApp) return null;
 
   return (
     <>

--- a/src/lib/stores/authStore.ts
+++ b/src/lib/stores/authStore.ts
@@ -175,6 +175,11 @@ export const useAuthStore = create<AuthState>((set) => ({
       clearTokens();
       if (typeof window !== "undefined") {
         localStorage.removeItem("currentUser");
+        // Notify native app shell (splitbill-native WebView) so it can
+        // switch back to its native login screen.
+        (window as any).ReactNativeWebView?.postMessage(
+          JSON.stringify({ type: "LOGOUT" }),
+        );
       }
       clearUser();
       // Clear draft ID on logout to avoid account switching conflicts

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -73,3 +73,13 @@ export function getAvatarUrl(user?: { email?: string | null; image?: string | nu
 export function getFriendAvatarUrl(name: string, size: number = 64) {
   return `https://api.dicebear.com/9.x/personas/svg?backgroundColor=b6e3f4,c0aede,d1d4f9,ffd5dc,ffdfbf&size=${size}&scale=100&seed=${encodeURIComponent(name)}`;
 }
+
+/**
+ * True when this page is loaded inside the splitbill-native WebView shell
+ * (which sets a custom UA suffix via `applicationNameForUserAgent`). The
+ * native shell has its own header/tab bar, so web-only chrome should hide.
+ */
+export function isNativeAppWebView() {
+  if (typeof navigator === "undefined") return false;
+  return navigator.userAgent.includes("SplitBillNativeApp");
+}


### PR DESCRIPTION
Detect the native WebView via a UA marker set by the app shell, then hide the web-only header/PWA banner/footer chrome on member pages and Footer everywhere else, since the native shell already provides its own navigation. Also posts a LOGOUT message back to the native shell on web-triggered logout so the app can bounce to its login screen.